### PR TITLE
fix: include UTI-declared app support

### DIFF
--- a/src/commands/current.rs
+++ b/src/commands/current.rs
@@ -20,7 +20,7 @@ pub fn run(ext: &str) -> Result<()> {
     }
     let supporting: Vec<&str> = apps
         .iter()
-        .filter(|app| app.extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)))
+        .filter(|app| scanner::app_supports_extension(app, ext))
         .map(|app| app.name.as_str())
         .collect();
 

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -169,9 +169,14 @@ impl App {
     fn build_apps_entries(apps: &[AppInfo], rows: &[ExtRow]) -> Vec<AppBrowserEntry> {
         let mut entries: Vec<AppBrowserEntry> = apps
             .iter()
-            .filter(|a| !a.extensions.is_empty() && !a.bundle_id.is_empty())
+            .filter(|a| !a.bundle_id.is_empty())
             .map(|a| {
                 let mut supported = a.extensions.clone();
+                supported.extend(
+                    rows.iter()
+                        .filter(|row| scanner::app_supports_extension(a, &row.ext))
+                        .map(|row| row.ext.clone()),
+                );
                 supported.sort();
                 supported.dedup();
                 let default_for: Vec<String> = supported
@@ -191,6 +196,7 @@ impl App {
                     default_for,
                 }
             })
+            .filter(|a| !a.supported.is_empty())
             .collect();
         entries.sort_by_key(|a| a.name.to_lowercase());
         entries
@@ -225,7 +231,7 @@ impl App {
         let mut supporting: Vec<String> = self
             .apps
             .iter()
-            .filter(|a| a.extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)))
+            .filter(|a| scanner::app_supports_extension(a, ext))
             .map(|a| a.name.clone())
             .collect();
         supporting.sort();

--- a/src/core/plist.rs
+++ b/src/core/plist.rs
@@ -2,10 +2,16 @@ use anyhow::Result;
 use std::collections::HashSet;
 use std::process::Command;
 
-/// Parse an application's Info.plist to extract supported file extensions.
-pub fn parse_extensions(plist_path: &str) -> Result<Vec<String>> {
+#[derive(Debug, Default)]
+pub struct DocumentTypes {
+    pub extensions: Vec<String>,
+    pub content_types: Vec<String>,
+}
+
+/// Parse an application's Info.plist document declarations.
+pub fn parse_document_types(plist_path: &str) -> Result<DocumentTypes> {
     if !std::path::Path::new(plist_path).exists() {
-        return Ok(vec![]);
+        return Ok(DocumentTypes::default());
     }
 
     let output = Command::new("/usr/libexec/PlistBuddy")
@@ -14,29 +20,118 @@ pub fn parse_extensions(plist_path: &str) -> Result<Vec<String>> {
         .arg(plist_path)
         .output();
 
-    let mut extensions = HashSet::new();
-
     if let Ok(output) = output {
         let content = String::from_utf8_lossy(&output.stdout);
-        let mut is_collecting = false;
-
-        for line in content.lines() {
-            let line = line.trim();
-            if line == "}" && is_collecting {
-                is_collecting = false;
-                continue;
-            }
-            if is_collecting && !line.is_empty() {
-                extensions.insert(line.to_string());
-                continue;
-            }
-            if line == "CFBundleTypeExtensions = Array {" {
-                is_collecting = true;
-            }
-        }
+        return Ok(parse_document_types_output(&content));
     }
 
-    let mut result: Vec<String> = extensions.into_iter().collect();
+    Ok(DocumentTypes::default())
+}
+
+fn parse_document_types_output(content: &str) -> DocumentTypes {
+    let mut extensions = HashSet::new();
+    let mut content_types = HashSet::new();
+    let mut collecting = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line == "}" && collecting.is_some() {
+            collecting = None;
+            continue;
+        }
+
+        match collecting {
+            Some(DocumentTypeArray::Extensions) => {
+                insert_normalized(&mut extensions, line, true);
+                continue;
+            }
+            Some(DocumentTypeArray::ContentTypes) => {
+                insert_normalized(&mut content_types, line, false);
+                continue;
+            }
+            None => {}
+        }
+
+        collecting = match line {
+            "CFBundleTypeExtensions = Array {" => Some(DocumentTypeArray::Extensions),
+            "LSItemContentTypes = Array {" => Some(DocumentTypeArray::ContentTypes),
+            _ => None,
+        };
+    }
+
+    DocumentTypes {
+        extensions: sorted(extensions),
+        content_types: sorted(content_types),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DocumentTypeArray {
+    Extensions,
+    ContentTypes,
+}
+
+fn insert_normalized(values: &mut HashSet<String>, value: &str, is_extension: bool) {
+    let value = value.trim().to_lowercase();
+    let value = if is_extension {
+        value.trim_start_matches('.')
+    } else {
+        &value
+    };
+
+    if !value.is_empty() && value != "*" {
+        values.insert(value.to_string());
+    }
+}
+
+fn sorted(values: HashSet<String>) -> Vec<String> {
+    let mut result: Vec<String> = values.into_iter().collect();
     result.sort();
-    Ok(result)
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_document_types_output;
+
+    #[test]
+    fn parses_legacy_bundle_type_extensions() {
+        let content = r#"
+Array {
+    Dict {
+        CFBundleTypeExtensions = Array {
+            md
+            markdown
+        }
+    }
+}
+"#;
+
+        let document_types = parse_document_types_output(content);
+
+        assert_eq!(document_types.extensions, vec!["markdown", "md"]);
+        assert!(document_types.content_types.is_empty());
+    }
+
+    #[test]
+    fn parses_ls_item_content_types_without_mapping_them() {
+        let content = r#"
+Array {
+    Dict {
+        LSItemContentTypes = Array {
+            public.jpeg
+            public.plain-text
+        }
+    }
+}
+"#;
+
+        let document_types = parse_document_types_output(content);
+
+        assert!(document_types.extensions.is_empty());
+        assert_eq!(
+            document_types.content_types,
+            vec!["public.jpeg", "public.plain-text"]
+        );
+    }
 }

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -2,47 +2,61 @@ use anyhow::{Result, bail};
 use std::path::Path;
 use std::process::Command;
 
-use super::plist;
 use super::types::AppInfo;
+use super::{plist, uti};
 
 /// Scan the system for installed applications, returning their paths.
 pub fn scan_app_paths() -> Result<Vec<String>> {
     let mut app_paths = Vec::new();
 
-    let output = Command::new("mdfind")
+    if let Ok(output) = Command::new("mdfind")
         .arg("kMDItemContentType == 'com.apple.application-bundle'")
         .arg("-onlyin")
         .arg("/System/Applications")
         .arg("-onlyin")
         .arg("/Applications")
-        .output()?;
-
-    let content = String::from_utf8_lossy(&output.stdout);
-    for line in content.lines() {
-        let line = line.trim();
-        if !line.is_empty() && line.ends_with(".app") {
-            app_paths.push(line.to_string());
+        .output()
+    {
+        let content = String::from_utf8_lossy(&output.stdout);
+        for line in content.lines() {
+            let line = line.trim();
+            if !line.is_empty() && line.ends_with(".app") {
+                app_paths.push(line.to_string());
+            }
         }
     }
 
-    // Add user ~/Applications
+    collect_app_paths_from_dir(Path::new("/System/Applications"), 3, &mut app_paths);
+    collect_app_paths_from_dir(Path::new("/Applications"), 3, &mut app_paths);
+
     if let Ok(home) = std::env::var("HOME") {
         let user_apps = format!("{}/Applications", home);
-        if let Ok(entries) = std::fs::read_dir(&user_apps) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension() == Some(std::ffi::OsStr::new("app"))
-                    && let Some(path_str) = path.to_str()
-                {
-                    app_paths.push(path_str.to_string());
-                }
-            }
-        }
+        collect_app_paths_from_dir(Path::new(&user_apps), 3, &mut app_paths);
     }
 
     app_paths.sort();
     app_paths.dedup();
     Ok(app_paths)
+}
+
+fn collect_app_paths_from_dir(dir: &Path, max_depth: usize, app_paths: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension() == Some(std::ffi::OsStr::new("app")) {
+            if let Some(path_str) = path.to_str() {
+                app_paths.push(path_str.to_string());
+            }
+            continue;
+        }
+
+        if max_depth > 0 && path.is_dir() {
+            collect_app_paths_from_dir(&path, max_depth - 1, app_paths);
+        }
+    }
 }
 
 /// Read CFBundleIdentifier from an app's Info.plist via PlistBuddy.
@@ -74,17 +88,33 @@ pub fn scan_all_apps() -> Result<Vec<AppInfo>> {
         };
 
         let info_plist = format!("{}/Contents/Info.plist", app_path);
-        let extensions = plist::parse_extensions(&info_plist).unwrap_or_default();
+        let document_types = plist::parse_document_types(&info_plist).unwrap_or_default();
         let bundle_id = read_bundle_id_from_plist(&info_plist).unwrap_or_default();
 
         apps.push(AppInfo {
             name,
             bundle_id,
-            extensions,
+            extensions: document_types.extensions,
+            content_types: document_types.content_types,
         });
     }
 
     Ok(apps)
+}
+
+pub fn app_supports_extension(app: &AppInfo, ext: &str) -> bool {
+    let ext = ext.trim_start_matches('.');
+    if app.extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)) {
+        return true;
+    }
+
+    let Ok(ext_uti) = uti::uti_for_extension(ext) else {
+        return false;
+    };
+
+    app.content_types
+        .iter()
+        .any(|content_type| uti::conforms_to(content_type, &ext_uti))
 }
 
 /// Resolve an app name using exact match first, then a unique fuzzy match.
@@ -147,14 +177,17 @@ fn ambiguous_app_message(search: &str, matches: &[&AppInfo]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_app;
+    use super::{collect_app_paths_from_dir, resolve_app};
     use crate::core::types::AppInfo;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn app(name: &str, bundle_id: &str) -> AppInfo {
         AppInfo {
             name: name.to_string(),
             bundle_id: bundle_id.to_string(),
             extensions: vec![],
+            content_types: vec![],
         }
     }
 
@@ -194,5 +227,42 @@ mod tests {
         assert!(err.contains("ambiguous"));
         assert!(err.contains("Visual Studio Code"));
         assert!(err.contains("CodeRunner"));
+    }
+
+    #[test]
+    fn filesystem_scan_finds_nested_app_bundles() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("openwith-scan-test-{unique}"));
+        let nested_app = root.join("Utilities").join("Preview.app");
+        fs::create_dir_all(&nested_app).unwrap();
+
+        let mut paths = Vec::new();
+        collect_app_paths_from_dir(&root, 3, &mut paths);
+
+        assert_eq!(paths, vec![nested_app.to_string_lossy().to_string()]);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn app_supports_extension_uses_declared_content_type_direction() {
+        let broad_text_app = AppInfo {
+            name: "Broad Text App".to_string(),
+            bundle_id: "example.broad-text".to_string(),
+            extensions: vec![],
+            content_types: vec!["public.text".to_string()],
+        };
+        let markdown_app = AppInfo {
+            name: "Markdown App".to_string(),
+            bundle_id: "example.markdown".to_string(),
+            extensions: vec![],
+            content_types: vec!["net.daringfireball.markdown".to_string()],
+        };
+
+        assert!(!super::app_supports_extension(&broad_text_app, "md"));
+        assert!(super::app_supports_extension(&markdown_app, "md"));
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -4,4 +4,5 @@ pub struct AppInfo {
     pub name: String,
     pub bundle_id: String,
     pub extensions: Vec<String>,
+    pub content_types: Vec<String>,
 }

--- a/src/core/uti.rs
+++ b/src/core/uti.rs
@@ -11,6 +11,8 @@ unsafe extern "C" {
         in_tag: CFStringRef,
         in_conforming_to_uti: CFStringRef,
     ) -> CFStringRef;
+
+    fn UTTypeConformsTo(in_uti: CFStringRef, in_conforms_to_uti: CFStringRef) -> bool;
 }
 
 /// Resolve the UTI for a file extension.
@@ -23,6 +25,16 @@ pub fn uti_for_extension(ext: &str) -> Result<String> {
     }
 
     system_uti(&ext)
+}
+
+pub fn conforms_to(uti: &str, parent_uti: &str) -> bool {
+    if uti.eq_ignore_ascii_case(parent_uti) {
+        return true;
+    }
+
+    let uti = CFString::new(uti);
+    let parent_uti = CFString::new(parent_uti);
+    unsafe { UTTypeConformsTo(uti.as_concrete_TypeRef(), parent_uti.as_concrete_TypeRef()) }
 }
 
 fn system_uti(ext: &str) -> Result<String> {


### PR DESCRIPTION
Fixes #2

## Summary
- Parse LSItemContentTypes in addition to CFBundleTypeExtensions
- Use UTI conformance for extension-specific supporting app checks
- Add filesystem fallback scanning for app bundles when Spotlight is incomplete
- Keep broad parent content types from overmatching specific extensions like .md