### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,24 @@
 **OpenWith** is a small Rust-based macOS terminal tool for inspecting and managing default apps for file types. It lets you see which app is currently set as the default for each file extension and update those associations from one place, without repetitive clicks or guessing bundle IDs.
 
 
-## Prerequisites
-
-OpenWith requires Rust. Install it via [rustup](https://rustup.rs):
-
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
 ## Install
 
-```bash
-# From GitHub
-cargo install --git https://github.com/ColeMei/openwith
+Homebrew is the recommended install path:
 
-# Or clone and build locally
+```bash
+brew tap ColeMei/openwith
+brew install openwith
+```
+
+If you prefer installing from source with Cargo, install Rust via [rustup](https://rustup.rs), then run:
+
+```bash
+cargo install --git https://github.com/ColeMei/openwith
+```
+
+For local development builds from this repository:
+
+```bash
 cargo install --path .
 ```
 


### PR DESCRIPTION
Fixes #1

## Summary
- Make Homebrew the primary OpenWith install path in the README.
- Keep Cargo install documented as the source-install fallback.
- Leave the local `cargo install --path .` flow for development builds.

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

## Manual Install Plan
After the tap and formula are published for `v0.3.2`, validate the public install path with:

```sh
brew tap ColeMei/openwith
brew install openwith
"$(brew --prefix openwith)/bin/openwith" --version
```
