### PR TITLE
release: v0.4.0 — correctness, scriptability, and URL scheme support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,5 @@ jobs:
         run: cargo check
       - name: Lint
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Test
+        run: cargo test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,151 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+openwith is a macOS-only CLI tool (Rust) that manages file extension associations ("Open With" defaults) and URL scheme handlers. It scans installed apps, queries/sets defaults via native macOS Launch Services APIs. Has both a ratatui-based TUI and non-interactive CLI subcommands. Supports exporting/importing associations as TOML for dotfile portability.
+
+## Build & Run
+
+```bash
+cargo build --release              # production build
+cargo run                          # TUI mode (extensions view)
+cargo run -- apps                  # TUI mode (apps view)
+cargo run -- list                  # TUI mode (extensions view)
+cargo run -- list --json           # JSON output for scripts
+cargo run -- current pdf           # show default for .pdf
+cargo run -- set pdf Preview       # set default for .pdf
+cargo run -- current -s http       # show default browser
+cargo run -- set -s http Firefox   # set default browser
+cargo run -- export -o out.toml    # export associations to TOML
+cargo run -- import --dry-run out.toml  # preview an import
+cargo run -- import out.toml       # import associations from TOML
+cargo check                        # quick compile check
+cargo test                         # run tests
+cargo clippy                       # lint checks
+```
+
+## Architecture
+
+```
+src/
+  main.rs              -- clap CLI dispatch
+  cli.rs               -- clap derive structs, custom help template with ASCII logo
+  logo.rs              -- shared ASCII art logo constant
+  commands/
+    list.rs            -- `openwith list`: TUI on a terminal, plain/JSON when scripted
+    current.rs         -- `openwith current <ext>` (+ `-s` for URL schemes, `--json`)
+    set.rs             -- `openwith set <ext> <app>` with name/bundle-ID resolution
+    export.rs          -- `openwith export` dump associations + schemes to TOML
+    import.rs          -- `openwith import` apply TOML (idempotent, `--dry-run`)
+    tui.rs             -- ratatui TUI: Extensions + Apps tabs, loading screen, AppPicker + Help
+  core/
+    scanner.rs         -- app discovery via mdfind + fs walk, app/bundle-ID resolution
+    plist.rs           -- Info.plist parsing via the plist crate (extensions, content types, URL schemes)
+    launchservices.rs  -- native macOS Launch Services FFI: UTI and URL scheme handlers
+    uti.rs             -- UTI resolution: system lookup first, hardcoded fallback map, memoized; shared-UTI sibling detection
+    listing.rs         -- parallel default-handler queries shared by TUI, export, and list
+    config.rs          -- TOML export/import logic ([associations] + [schemes])
+    types.rs           -- AppInfo
+```
+
+### Key patterns
+
+- `core/launchservices.rs` uses FFI to `LSCopyDefaultRoleHandlerForContentType`, `LSSetDefaultRoleHandlerForContentType`, and the URL scheme equivalents. No external CLI dependencies.
+- `core/uti.rs` asks Launch Services for the UTI first (the mapping Finder actually uses) and falls back to a hardcoded table only for extensions the system maps to a dynamic (`dyn.*`) type. Lookups are memoized process-wide.
+- macOS maps defaults to UTIs, not extensions; `uti::extensions_sharing_uti` finds sibling extensions so commands can warn about side effects.
+- `core/scanner.rs` has `resolve_app_or_bundle_id(apps, value)` accepting app names or bundle IDs, and `resolve_name(apps, bundle_id)` to map bundle IDs back to app names.
+- `core/listing.rs` parallelizes default queries using `std::thread::scope` with chunks of 20; the TUI runs it in a background thread behind the loading screen.
+- TUI uses a `Tab` enum (`Extensions`, `Apps`) and a `View` enum state machine: `ExtensionList`, `AppPicker`, `AppsBrowser`, `Help`. Terminal setup is wrapped in an RAII guard plus a panic hook so raw mode is always restored.
+- `Tab` key switches between Extensions and Apps views at top level; inside `AppPicker`, `Tab` toggles supporting/all apps.
+- Apps browser uses a master-detail layout: left pane is app list, right pane shows details (supported extensions, defaults).
+- Loading screen enters TUI alternate screen immediately, shows ASCII logo + spinner while scanning in background.
+- Export/import uses serde + toml crate with `BTreeMap<String, String>` for sorted, human-readable TOML; import validates apps exist and skips associations already set correctly.
+
+## Runtime dependencies
+
+- `mdfind` -- macOS built-in used for app discovery (with a filesystem-walk fallback).
+- No external tools required (duti removed in v0.2.0, PlistBuddy removed in v0.4.0).
+
+## Development Workflow
+
+### Git commits
+
+- One logical change per commit — a single bug fix, a single feature, or a single refactor.
+- Never bundle unrelated changes into one commit.
+- Stage files selectively (`git add <file>...`), not `git add -A`.
+- Commit message style: `type: concise description` where type is one of `feat`, `fix`, `refactor`, `docs`, `chore`, `test`.
+- Run `cargo fmt` before every commit.
+- Keep `main` linear. Use squash merge for pull requests by default:
+  ```bash
+  gh pr merge <number> --squash --delete-branch
+  ```
+- Do not use merge commits unless explicitly requested.
+- If a release tag has already been pushed, do not rewrite history just to linearize it.
+
+### Versioning (SemVer-ish)
+
+| Bump | When | Example |
+|------|------|---------|
+| `0.0.x` (patch) | Bug fixes, small tweaks, docs | v0.1.1 |
+| `0.x.0` (minor) | New features, notable behavior changes | v0.2.0 |
+| `x.0.0` (major) | Reserved — standalone app, public distribution, breaking changes | future |
+
+When releasing, also update `version` in `Cargo.toml` to match the tag.
+
+### Release process
+
+1. Ensure all changes are committed and pushed.
+2. Update `Cargo.toml` version if not already done.
+3. Run validation:
+   ```bash
+   cargo fmt --check
+   cargo check
+   cargo clippy --all-targets --all-features -- -D warnings
+   cargo test
+   ```
+4. Create a git tag: `git tag vX.Y.Z`
+5. Push the tag: `git push origin vX.Y.Z`
+6. Create GitHub release with `gh release create` using the appropriate template below.
+7. Bump the Homebrew formula in `ColeMei/homebrew-openwith` (url + sha256 of the new tag tarball).
+
+### Release templates
+
+**Minor release (0.x.0) — new features:**
+
+```
+<one-line summary of the theme of this release>
+
+**Features**
+- <new capability 1>
+- <new capability 2>
+
+**Changes**
+- <notable behavior change or improvement>
+
+**Fixes**
+- <bug fix, if any>
+
+**Install**
+\```bash
+brew tap ColeMei/openwith
+brew install openwith
+\```
+```
+
+**Patch release (0.0.x) — bug fixes:**
+
+```
+<one-line summary>
+
+**Fixes**
+- <fix 1>
+- <fix 2>
+
+**Install**
+\```bash
+brew tap ColeMei/openwith
+brew install openwith
+\```
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "plist",
  "ratatui",
  "serde",
+ "serde_json",
  "toml",
 ]
 
@@ -592,6 +593,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -921,3 +935,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +231,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "either"
@@ -391,6 +403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +422,7 @@ dependencies = [
  "clap",
  "core-foundation",
  "crossterm",
+ "plist",
  "ratatui",
  "serde",
  "toml",
@@ -439,12 +458,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -636,6 +683,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openwith"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +145,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -420,6 +439,8 @@ version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "core-foundation",
  "crossterm",
  "plist",
@@ -533,6 +554,12 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0"
 clap = { version = "4", features = ["derive"] }
 core-foundation = "0.10"
 crossterm = "0.28"
+plist = "1"
 ratatui = "0.29"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ crossterm = "0.28"
 plist = "1"
 ratatui = "0.29"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwith"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 description = "Manage macOS file extension associations"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+clap_mangen = "0.2"
 core-foundation = "0.10"
 crossterm = "0.28"
 plist = "1"

--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ cargo install --path .
 ## Quick Start
 
 ```bash
-openwith                # Launch interactive TUI (extensions view)
-openwith list           # Same as above
-openwith apps           # Launch interactive TUI (apps view)
-openwith current pdf    # Show default app for .pdf
-openwith set md Typora  # Set Typora as default for .md
+openwith                    # Launch interactive TUI (extensions view)
+openwith list               # Same as above
+openwith apps               # Launch interactive TUI (apps view)
+openwith current pdf        # Show default app for .pdf
+openwith set md Typora      # Set Typora as default for .md
+openwith set md abnerworks.Typora  # Bundle IDs work too
+openwith current -s http    # Show the default browser
+openwith set -s http Firefox      # Set the default browser
 ```
 
 Run `openwith --help` to see all commands.
@@ -71,17 +74,40 @@ Press `?` inside the TUI for keyboard shortcuts.
 You can export your current associations to a TOML file and import them on another machine — making your "Open With" preferences portable, like a dotfile.
 
 ```bash
-openwith export -o openwith.toml  # Export
-openwith import openwith.toml     # Import on a new machine
+openwith export -o openwith.toml    # Export
+openwith import --dry-run openwith.toml  # Preview what would change
+openwith import openwith.toml       # Import on a new machine
 ```
 
-Import skips associations where the app isn't found, so the same config works across machines with different setups.
+The export includes a `[schemes]` table for URL handlers (browser, mail client). Import is idempotent: associations already set correctly are left untouched, apps that aren't installed are skipped, and every change reports what it replaced — so the same config works across machines with different setups and is safe to run from a dotfiles script.
+
+### Scripting
+
+`openwith list` prints a plain table instead of launching the TUI when its output is piped, and `--plain` / `--json` force either format:
+
+```bash
+openwith list --json | jq -r '.[] | select(.app == "Preview") | .ext'
+openwith current pdf --json
+```
+
+### Shell completions
+
+```bash
+openwith completions zsh > "${fpath[1]}/_openwith"   # zsh
+openwith completions bash > $(brew --prefix)/etc/bash_completion.d/openwith
+openwith completions fish > ~/.config/fish/completions/openwith.fish
+```
 
 ## How It Works
 
 1. Scans `/Applications`, `/System/Applications`, and `~/Applications` for `.app` bundles
-2. Reads each app's `Info.plist` to discover supported file extensions
+2. Reads each app's `Info.plist` to discover supported file extensions and URL schemes
 3. Queries and sets defaults via native macOS Launch Services APIs
+
+## Caveats
+
+- **macOS associates defaults with file *types* (UTIs), not extensions.** Some extensions share a type: `.env` resolves to `public.plain-text`, the same type as `.txt`, so changing one changes the other. `openwith` warns you and lists the affected sibling extensions whenever this happens.
+- Finder occasionally caches icons/defaults; if a change doesn't appear immediately, relaunch Finder or log out and back in. The association itself is applied instantly.
 
 ## License
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,8 @@ BROWSE
 MANAGE
     openwith current <ext>      Show the default app (--json for scripts)
     openwith set <ext> <app>    Set the default app (name or bundle ID)
+    openwith current -s http    Show the handler for a URL scheme
+    openwith set -s http <app>  Set the handler for a URL scheme
 
 CONFIG
     openwith export         Export current associations to TOML
@@ -73,20 +75,26 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Show the current default app for a specific extension
+    /// Show the current default app for an extension or URL scheme
     Current {
-        /// File extension (without dot)
+        /// File extension (without dot), or URL scheme with --scheme
         ext: String,
         /// Print JSON
         #[arg(long)]
         json: bool,
+        /// Treat the argument as a URL scheme (e.g. http, mailto)
+        #[arg(short = 's', long)]
+        scheme: bool,
     },
-    /// Set the default app for a file extension
+    /// Set the default app for a file extension or URL scheme
     Set {
-        /// File extension (without dot)
+        /// File extension (without dot), or URL scheme with --scheme
         ext: String,
         /// Application name or bundle ID (e.g., "Preview", "com.apple.Preview")
         app: String,
+        /// Treat the argument as a URL scheme (e.g. http, mailto)
+        #[arg(short = 's', long)]
+        scheme: bool,
     },
     /// Launch interactive TUI (apps view)
     Apps,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,5 +91,8 @@ pub enum Commands {
     Import {
         /// Path to TOML config file
         path: String,
+        /// Preview the changes without applying them
+        #[arg(long)]
+        dry_run: bool,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,16 +13,16 @@ fn help_template() -> String {
 
 BROWSE
     openwith                Launch interactive TUI (extensions view)
-    openwith list           Launch interactive TUI (extensions view)
+    openwith list           Launch interactive TUI; --plain/--json for scripts
     openwith apps           Launch interactive TUI (apps view)
 
 MANAGE
-    openwith current <ext>      Show the default app for an extension
-    openwith set <ext> <app>    Set the default app for an extension
+    openwith current <ext>      Show the default app (--json for scripts)
+    openwith set <ext> <app>    Set the default app (name or bundle ID)
 
 CONFIG
     openwith export         Export current associations to TOML
-    openwith import <path>  Import associations from a TOML file
+    openwith import <path>  Import associations (--dry-run to preview)
 
 FLAGS
     -h, --help              Show help
@@ -37,8 +37,7 @@ FLAGS
     about = "Manage macOS file extension associations",
     version,
     disable_version_flag = true,
-    disable_help_flag = true,
-    subcommand_negates_reqs = true
+    disable_help_flag = true
 )]
 pub struct Cli {
     /// Print version
@@ -65,22 +64,32 @@ impl Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Launch interactive TUI (extensions view)
-    List {},
+    /// Launch interactive TUI (extensions view); plain/JSON when scripted
+    List {
+        /// Print a plain table instead of launching the TUI
+        #[arg(long, conflicts_with = "json")]
+        plain: bool,
+        /// Print JSON instead of launching the TUI
+        #[arg(long)]
+        json: bool,
+    },
     /// Show the current default app for a specific extension
     Current {
         /// File extension (without dot)
         ext: String,
+        /// Print JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Set the default app for a file extension
     Set {
         /// File extension (without dot)
         ext: String,
-        /// Application name (e.g., "Preview", "Visual Studio Code")
+        /// Application name or bundle ID (e.g., "Preview", "com.apple.Preview")
         app: String,
     },
     /// Launch interactive TUI (apps view)
-    Apps {},
+    Apps,
     /// Export current file associations to TOML
     Export {
         /// Output file path (default: stdout)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ MANAGE
 CONFIG
     openwith export         Export current associations to TOML
     openwith import <path>  Import associations (--dry-run to preview)
+    openwith completions <shell>    Generate shell completions
 
 FLAGS
     -h, --help              Show help
@@ -112,4 +113,13 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+    /// Generate a man page (roff) on stdout
+    #[command(hide = true)]
+    Mangen,
 }

--- a/src/commands/current.rs
+++ b/src/commands/current.rs
@@ -2,7 +2,11 @@ use anyhow::Result;
 
 use crate::core::{launchservices, scanner};
 
-pub fn run(ext: &str, json: bool) -> Result<()> {
+pub fn run(ext: &str, json: bool, scheme: bool) -> Result<()> {
+    if scheme {
+        return run_scheme(ext, json);
+    }
+
     let ext = ext.trim_start_matches('.');
 
     eprintln!("Scanning applications...");
@@ -45,4 +49,64 @@ pub fn run(ext: &str, json: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn run_scheme(scheme: &str, json: bool) -> Result<()> {
+    let scheme = normalize_scheme(scheme);
+
+    eprintln!("Scanning applications...");
+    let apps = scanner::scan_all_apps()?;
+
+    let bundle_id = launchservices::query_default_scheme_handler(&scheme)?;
+    let name = bundle_id
+        .as_ref()
+        .map(|bid| scanner::resolve_name(&apps, bid));
+
+    let supporting: Vec<&str> = apps
+        .iter()
+        .filter(|app| {
+            app.url_schemes
+                .iter()
+                .any(|s| s.eq_ignore_ascii_case(&scheme))
+        })
+        .map(|app| app.name.as_str())
+        .collect();
+
+    if json {
+        let out = serde_json::json!({
+            "scheme": scheme,
+            "app": name,
+            "bundle_id": bundle_id,
+            "supporting_apps": supporting,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    match (&name, &bundle_id) {
+        (Some(name), Some(bundle_id)) => {
+            println!("{}:// -> {} ({})", scheme, name, bundle_id)
+        }
+        _ => println!("{}:// -> (no default set)", scheme),
+    }
+
+    if supporting.is_empty() {
+        println!("No apps found that declare support for {}://", scheme);
+    } else {
+        println!("\nApps supporting {}://:", scheme);
+        for app in &supporting {
+            println!("  {}", app);
+        }
+    }
+
+    Ok(())
+}
+
+/// Accept "http", "http:", or "http://" and normalize to the bare scheme.
+pub fn normalize_scheme(scheme: &str) -> String {
+    scheme
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(':')
+        .to_lowercase()
 }

--- a/src/commands/current.rs
+++ b/src/commands/current.rs
@@ -2,27 +2,38 @@ use anyhow::Result;
 
 use crate::core::{launchservices, scanner};
 
-pub fn run(ext: &str) -> Result<()> {
+pub fn run(ext: &str, json: bool) -> Result<()> {
     let ext = ext.trim_start_matches('.');
 
     eprintln!("Scanning applications...");
     let apps = scanner::scan_all_apps()?;
 
-    // Query current default
-    match launchservices::query_default_bundle_id(ext)? {
-        Some(bundle_id) => {
-            let name = scanner::resolve_name(&apps, &bundle_id);
-            println!(".{} -> {} ({})", ext, name, bundle_id);
-        }
-        None => {
-            println!(".{} -> (no default set)", ext);
-        }
-    }
+    let bundle_id = launchservices::query_default_bundle_id(ext)?;
+    let name = bundle_id
+        .as_ref()
+        .map(|bid| scanner::resolve_name(&apps, bid));
+
     let supporting: Vec<&str> = apps
         .iter()
         .filter(|app| scanner::app_supports_extension(app, ext))
         .map(|app| app.name.as_str())
         .collect();
+
+    if json {
+        let out = serde_json::json!({
+            "ext": ext,
+            "app": name,
+            "bundle_id": bundle_id,
+            "supporting_apps": supporting,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    match (&name, &bundle_id) {
+        (Some(name), Some(bundle_id)) => println!(".{} -> {} ({})", ext, name, bundle_id),
+        _ => println!(".{} -> (no default set)", ext),
+    }
 
     if supporting.is_empty() {
         println!("No apps found that declare support for .{}", ext);

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -14,8 +14,9 @@ pub fn run(output: Option<&str>) -> Result<()> {
         Some(path) => {
             std::fs::write(path, &toml_str)?;
             println!(
-                "Exported {} associations to {}",
+                "Exported {} associations and {} scheme handlers to {}",
                 cfg.associations.len(),
+                cfg.schemes.len(),
                 path
             );
         }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 
-use crate::core::{config, scanner};
+use crate::core::{config, scanner, uti};
 
 pub fn run(path: &str) -> Result<()> {
     let content =
@@ -18,8 +19,34 @@ pub fn run(path: &str) -> Result<()> {
     eprintln!("Applying {} associations...", cfg.associations.len());
     let result = config::import_associations(&cfg, &apps);
 
+    // Warn about extensions changed as a side effect of a shared UTI,
+    // unless they are themselves part of the import.
+    let all_extensions = scanner::all_extensions(&apps);
+    let imported: HashSet<String> = cfg
+        .associations
+        .keys()
+        .map(|k| k.trim_start_matches('.').to_lowercase())
+        .collect();
+
     for (ext, app) in &result.applied {
         println!("  {} -> {}", ext, app);
+
+        if let Ok(uti_str) = uti::uti_for_extension(ext) {
+            let siblings: Vec<String> = uti::extensions_sharing_uti(ext, &uti_str, &all_extensions)
+                .into_iter()
+                .filter(|s| !imported.contains(s))
+                .collect();
+            if !siblings.is_empty() {
+                let shown: Vec<String> = siblings.iter().take(6).map(|s| format!(".{s}")).collect();
+                let extra = siblings.len().saturating_sub(6);
+                let more = if extra > 0 {
+                    format!(" +{extra}")
+                } else {
+                    String::new()
+                };
+                println!("    also affects {}{}", shown.join(", "), more);
+            }
+        }
     }
 
     if !result.skipped.is_empty() {

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use crate::core::{config, scanner, uti};
 
-pub fn run(path: &str) -> Result<()> {
+pub fn run(path: &str, dry_run: bool) -> Result<()> {
     let content =
         std::fs::read_to_string(path).with_context(|| format!("failed to read '{}'", path))?;
     let cfg = config::from_toml(&content)?;
@@ -16,8 +16,15 @@ pub fn run(path: &str) -> Result<()> {
     eprintln!("Scanning applications...");
     let apps = scanner::scan_all_apps()?;
 
-    eprintln!("Applying {} associations...", cfg.associations.len());
-    let result = config::import_associations(&cfg, &apps);
+    if dry_run {
+        eprintln!(
+            "Previewing {} associations (dry run)...",
+            cfg.associations.len()
+        );
+    } else {
+        eprintln!("Applying {} associations...", cfg.associations.len());
+    }
+    let result = config::import_associations(&cfg, &apps, dry_run);
 
     // Warn about extensions changed as a side effect of a shared UTI,
     // unless they are themselves part of the import.
@@ -49,6 +56,10 @@ pub fn run(path: &str) -> Result<()> {
         }
     }
 
+    if !result.unchanged.is_empty() {
+        println!("  {} already set correctly", result.unchanged.len());
+    }
+
     if !result.skipped.is_empty() {
         eprintln!();
         for (ext, app, reason) in &result.skipped {
@@ -57,8 +68,10 @@ pub fn run(path: &str) -> Result<()> {
     }
 
     println!(
-        "\nApplied {}, skipped {}",
+        "\n{} {}, unchanged {}, skipped {}",
+        if dry_run { "Would apply" } else { "Applied" },
         result.applied.len(),
+        result.unchanged.len(),
         result.skipped.len()
     );
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -35,8 +35,12 @@ pub fn run(path: &str, dry_run: bool) -> Result<()> {
         .map(|k| k.trim_start_matches('.').to_lowercase())
         .collect();
 
-    for (ext, app) in &result.applied {
-        println!("  {} -> {}", ext, app);
+    for (ext, app, previous) in &result.applied {
+        let was = previous
+            .as_ref()
+            .map(|p| format!(" (was: {p})"))
+            .unwrap_or_default();
+        println!("  {} -> {}{}", ext, app, was);
 
         if let Ok(uti_str) = uti::uti_for_extension(ext) {
             let siblings: Vec<String> = uti::extensions_sharing_uti(ext, &uti_str, &all_extensions)

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -8,7 +8,8 @@ pub fn run(path: &str, dry_run: bool) -> Result<()> {
         std::fs::read_to_string(path).with_context(|| format!("failed to read '{}'", path))?;
     let cfg = config::from_toml(&content)?;
 
-    if cfg.associations.is_empty() {
+    let total = cfg.associations.len() + cfg.schemes.len();
+    if total == 0 {
         println!("No associations found in '{}'.", path);
         return Ok(());
     }
@@ -17,12 +18,9 @@ pub fn run(path: &str, dry_run: bool) -> Result<()> {
     let apps = scanner::scan_all_apps()?;
 
     if dry_run {
-        eprintln!(
-            "Previewing {} associations (dry run)...",
-            cfg.associations.len()
-        );
+        eprintln!("Previewing {} associations (dry run)...", total);
     } else {
-        eprintln!("Applying {} associations...", cfg.associations.len());
+        eprintln!("Applying {} associations...", total);
     }
     let result = config::import_associations(&cfg, &apps, dry_run);
 
@@ -41,6 +39,11 @@ pub fn run(path: &str, dry_run: bool) -> Result<()> {
             .map(|p| format!(" (was: {p})"))
             .unwrap_or_default();
         println!("  {} -> {}{}", ext, app, was);
+
+        // Scheme entries (http://) have no UTI siblings.
+        if !ext.starts_with('.') {
+            continue;
+        }
 
         if let Ok(uti_str) = uti::uti_for_extension(ext) {
             let siblings: Vec<String> = uti::extensions_sharing_uti(ext, &uti_str, &all_extensions)

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use std::io::IsTerminal;
+
+use crate::core::{listing, scanner};
+
+use super::tui;
+
+/// `openwith list`: interactive TUI on a terminal, plain or JSON output for
+/// scripts. `--plain` / `--json` force the non-interactive formats; a piped
+/// stdout falls back to the plain table automatically.
+pub fn run(plain: bool, json: bool) -> Result<()> {
+    if json {
+        print_listing(true)
+    } else if plain || !std::io::stdout().is_terminal() {
+        print_listing(false)
+    } else {
+        tui::run(tui::InitialView::Extensions)
+    }
+}
+
+fn print_listing(json: bool) -> Result<()> {
+    eprintln!("Scanning applications...");
+    let apps = scanner::scan_all_apps()?;
+
+    eprintln!("Querying defaults...");
+    let rows = listing::query_all(&apps, &|| {});
+
+    if json {
+        let out: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "ext": r.ext,
+                    "app": r.app_name,
+                    "bundle_id": r.bundle_id,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    let ext_width = rows.iter().map(|r| r.ext.len()).max().unwrap_or(3);
+    let app_width = rows
+        .iter()
+        .map(|r| r.app_name.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(1);
+    for r in &rows {
+        println!(
+            "{:<ext_width$}  {:<app_width$}  {}",
+            r.ext,
+            r.app_name.as_deref().unwrap_or("-"),
+            r.bundle_id.as_deref().unwrap_or("-"),
+        );
+    }
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod current;
 pub mod export;
 pub mod import;
+pub mod list;
 pub mod set;
 pub mod tui;

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -5,28 +5,24 @@ use crate::core::{launchservices, scanner, uti};
 pub fn run(ext: &str, app_name: &str) -> Result<()> {
     let ext = ext.trim_start_matches('.');
 
-    // Find the app
+    // Find the app (by name or bundle ID)
     eprintln!("Scanning applications...");
     let apps = scanner::scan_all_apps()?;
-    let app = scanner::resolve_app(&apps, app_name)?;
-
-    if app.bundle_id.is_empty() {
-        anyhow::bail!("could not determine bundle ID for '{}'", app.name);
-    }
+    let (bundle_id, display_name) = scanner::resolve_app_or_bundle_id(&apps, app_name)?;
 
     // Resolve UTI
     let uti = uti::uti_for_extension(ext)?;
 
     // Set default
-    launchservices::set_default(&app.bundle_id, &uti)?;
+    launchservices::set_default(&bundle_id, &uti)?;
 
     // Verify
     match launchservices::query_default_bundle_id(ext)? {
-        Some(bid) if bid.eq_ignore_ascii_case(&app.bundle_id) => {
-            println!("Set .{} -> {}", ext, app.name);
+        Some(bid) if bid.eq_ignore_ascii_case(&bundle_id) => {
+            println!("Set .{} -> {}", ext, display_name);
         }
         _ => {
-            println!("Set .{} -> {} (could not verify)", ext, app.name);
+            println!("Set .{} -> {} (could not verify)", ext, display_name);
         }
     }
 

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -1,14 +1,21 @@
 use anyhow::Result;
 
+use crate::core::types::AppInfo;
 use crate::core::{launchservices, scanner, uti};
 
-pub fn run(ext: &str, app_name: &str) -> Result<()> {
-    let ext = ext.trim_start_matches('.');
+use super::current::normalize_scheme;
 
+pub fn run(ext: &str, app_name: &str, scheme: bool) -> Result<()> {
     // Find the app (by name or bundle ID)
     eprintln!("Scanning applications...");
     let apps = scanner::scan_all_apps()?;
     let (bundle_id, display_name) = scanner::resolve_app_or_bundle_id(&apps, app_name)?;
+
+    if scheme {
+        return run_scheme(&apps, ext, &bundle_id, &display_name);
+    }
+
+    let ext = ext.trim_start_matches('.');
 
     // Resolve UTI
     let uti = uti::uti_for_extension(ext)?;
@@ -44,6 +51,36 @@ pub fn run(ext: &str, app_name: &str) -> Result<()> {
     let siblings = uti::extensions_sharing_uti(ext, &uti, &scanner::all_extensions(&apps));
     if let Some(note) = uti::shared_uti_note(ext, &uti, &siblings) {
         eprintln!("note: {}", note);
+    }
+
+    Ok(())
+}
+
+fn run_scheme(apps: &[AppInfo], scheme: &str, bundle_id: &str, display_name: &str) -> Result<()> {
+    let scheme = normalize_scheme(scheme);
+
+    let previous = launchservices::query_default_scheme_handler(&scheme)?;
+    if previous
+        .as_deref()
+        .is_some_and(|p| p.eq_ignore_ascii_case(bundle_id))
+    {
+        println!("{}:// is already {} — nothing to do", scheme, display_name);
+        return Ok(());
+    }
+
+    launchservices::set_default_scheme_handler(bundle_id, &scheme)?;
+
+    let was = previous
+        .map(|p| format!(" (was: {})", scanner::resolve_name(apps, &p)))
+        .unwrap_or_default();
+
+    match launchservices::query_default_scheme_handler(&scheme)? {
+        Some(bid) if bid.eq_ignore_ascii_case(bundle_id) => {
+            println!("Set {}:// -> {}{}", scheme, display_name, was);
+        }
+        _ => {
+            println!("Set {}:// -> {} (could not verify)", scheme, display_name);
+        }
     }
 
     Ok(())

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -30,5 +30,10 @@ pub fn run(ext: &str, app_name: &str) -> Result<()> {
         }
     }
 
+    let siblings = uti::extensions_sharing_uti(ext, &uti, &scanner::all_extensions(&apps));
+    if let Some(note) = uti::shared_uti_note(ext, &uti, &siblings) {
+        eprintln!("note: {}", note);
+    }
+
     Ok(())
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -13,13 +13,28 @@ pub fn run(ext: &str, app_name: &str) -> Result<()> {
     // Resolve UTI
     let uti = uti::uti_for_extension(ext)?;
 
+    // Record the previous default so the change is easy to revert by hand,
+    // and skip the write entirely when nothing would change.
+    let previous = launchservices::query_default_bundle_id(ext)?;
+    if previous
+        .as_deref()
+        .is_some_and(|p| p.eq_ignore_ascii_case(&bundle_id))
+    {
+        println!(".{} is already {} — nothing to do", ext, display_name);
+        return Ok(());
+    }
+
     // Set default
     launchservices::set_default(&bundle_id, &uti)?;
+
+    let was = previous
+        .map(|p| format!(" (was: {})", scanner::resolve_name(&apps, &p)))
+        .unwrap_or_default();
 
     // Verify
     match launchservices::query_default_bundle_id(ext)? {
         Some(bid) if bid.eq_ignore_ascii_case(&bundle_id) => {
-            println!("Set .{} -> {}", ext, display_name);
+            println!("Set .{} -> {}{}", ext, display_name, was);
         }
         _ => {
             println!("Set .{} -> {} (could not verify)", ext, display_name);

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -315,6 +315,13 @@ impl App {
                         &scanner::all_extensions(&self.apps),
                     );
 
+                    let previous_name = self
+                        .all_rows
+                        .iter()
+                        .find(|r| r.ext == ext)
+                        .map(|r| r.app_name.clone())
+                        .filter(|n| n != "-" && !n.eq_ignore_ascii_case(&app_name));
+
                     if let Some(ref bid) = new_bid {
                         let mut affected = vec![ext.clone()];
                         affected.extend(siblings.iter().cloned());
@@ -339,6 +346,9 @@ impl App {
 
                     if verified {
                         let mut status = format!("Set .{} -> {}", ext, app_name);
+                        if let Some(prev) = previous_name {
+                            status.push_str(&format!(" (was {prev})"));
+                        }
                         if !siblings.is_empty() {
                             let shown: Vec<String> =
                                 siblings.iter().take(3).map(|s| format!(".{s}")).collect();

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use crate::core::types::AppInfo;
-use crate::core::{launchservices, scanner, uti};
+use crate::core::{launchservices, listing, scanner, uti};
 use crate::logo::LOGO;
 
 /// Which view to show when the TUI starts.
@@ -608,38 +608,19 @@ fn load_data(phase: Arc<Mutex<LoadPhase>>, progress: Arc<AtomicUsize>) -> Result
         }
     };
 
-    let extensions = scanner::all_extensions(&apps);
-
-    let total = extensions.len();
+    let total = scanner::all_extensions(&apps).len();
     *phase.lock().unwrap() = LoadPhase::Querying { total };
 
-    let rows: Mutex<Vec<ExtRow>> = Mutex::new(Vec::new());
-    std::thread::scope(|s| {
-        for chunk in extensions.chunks(20) {
-            let rows = &rows;
-            let apps = &apps;
-            let progress = &progress;
-            let chunk = chunk.to_vec();
-            s.spawn(move || {
-                for ext in chunk {
-                    let bundle_id = launchservices::query_default_bundle_id(&ext).ok().flatten();
-                    let (app_name, bid) = match &bundle_id {
-                        Some(bid) => (scanner::resolve_name(apps, bid), bid.clone()),
-                        None => ("-".into(), "-".into()),
-                    };
-                    rows.lock().unwrap().push(ExtRow {
-                        ext,
-                        app_name,
-                        bundle_id: bid,
-                    });
-                    progress.fetch_add(1, Ordering::Relaxed);
-                }
-            });
-        }
-    });
-
-    let mut rows = rows.into_inner().unwrap();
-    rows.sort_by(|a, b| a.ext.cmp(&b.ext));
+    let rows: Vec<ExtRow> = listing::query_all(&apps, &|| {
+        progress.fetch_add(1, Ordering::Relaxed);
+    })
+    .into_iter()
+    .map(|assoc| ExtRow {
+        ext: assoc.ext,
+        app_name: assoc.app_name.unwrap_or_else(|| "-".into()),
+        bundle_id: assoc.bundle_id.unwrap_or_else(|| "-".into()),
+    })
+    .collect();
 
     *phase.lock().unwrap() = LoadPhase::Done(Some(LoadResult { apps, rows }));
     Ok(())

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -446,6 +446,39 @@ impl App {
 // Entry point
 // ---------------------------------------------------------------------------
 
+/// Restores the terminal on drop, so every exit path (including `?` early
+/// returns) leaves the user's shell usable.
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn enter() -> Result<Self> {
+        enable_raw_mode()?;
+        io::stdout().execute(EnterAlternateScreen)?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        restore_terminal();
+    }
+}
+
+fn restore_terminal() {
+    let _ = disable_raw_mode();
+    let _ = io::stdout().execute(LeaveAlternateScreen);
+}
+
+/// Restore the terminal before the default panic output runs, so the panic
+/// message is readable instead of vanishing with the alternate screen.
+fn install_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        default_hook(info);
+    }));
+}
+
 pub fn run(initial_view: InitialView) -> Result<()> {
     let initial_tab = match initial_view {
         InitialView::Extensions => Tab::Extensions,
@@ -453,8 +486,8 @@ pub fn run(initial_view: InitialView) -> Result<()> {
     };
 
     // Enter TUI immediately, scan in background
-    enable_raw_mode()?;
-    io::stdout().execute(EnterAlternateScreen)?;
+    install_panic_hook();
+    let guard = TerminalGuard::enter()?;
     let backend = ratatui::backend::CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
 
@@ -523,15 +556,13 @@ pub fn run(initial_view: InitialView) -> Result<()> {
     }
 
     if quit_during_load {
-        disable_raw_mode()?;
-        io::stdout().execute(LeaveAlternateScreen)?;
+        drop(guard);
         println!("Goodbye! \u{2014} openwith v{}", env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
 
     let Some(data) = load_result else {
-        disable_raw_mode()?;
-        io::stdout().execute(LeaveAlternateScreen)?;
+        drop(guard);
         anyhow::bail!("Failed to load application data");
     };
 
@@ -539,8 +570,7 @@ pub fn run(initial_view: InitialView) -> Result<()> {
 
     let result = run_loop(&mut terminal, &mut app);
 
-    disable_raw_mode()?;
-    io::stdout().execute(LeaveAlternateScreen)?;
+    drop(guard);
 
     // Exit summary
     if !app.changes.is_empty() {

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -307,21 +307,54 @@ impl App {
                         .map(|b| b.eq_ignore_ascii_case(&bundle_id))
                         .unwrap_or(false);
 
-                    // Update the extension row
-                    if let Some(row) = self.all_rows.iter_mut().find(|r| r.ext == ext)
-                        && let Some(ref bid) = new_bid
-                    {
-                        let old_bid = row.bundle_id.clone();
-                        row.app_name = scanner::resolve_name(&self.apps, bid);
-                        row.bundle_id = bid.clone();
+                    // The default follows the UTI, so every extension sharing
+                    // it changed too — update their rows as well.
+                    let siblings = uti::extensions_sharing_uti(
+                        &ext,
+                        &uti_str,
+                        &scanner::all_extensions(&self.apps),
+                    );
 
-                        // Update apps browser entries
-                        self.update_apps_browser_default(&ext, &old_bid, bid);
+                    if let Some(ref bid) = new_bid {
+                        let mut affected = vec![ext.clone()];
+                        affected.extend(siblings.iter().cloned());
+                        for affected_ext in &affected {
+                            let Some(row_idx) = self
+                                .all_rows
+                                .iter()
+                                .position(|r| r.ext.eq_ignore_ascii_case(affected_ext))
+                            else {
+                                continue;
+                            };
+                            let old_bid = self.all_rows[row_idx].bundle_id.clone();
+                            self.all_rows[row_idx].app_name =
+                                scanner::resolve_name(&self.apps, bid);
+                            self.all_rows[row_idx].bundle_id = bid.clone();
+
+                            // Update apps browser entries
+                            self.update_apps_browser_default(affected_ext, &old_bid, bid);
+                        }
                     }
                     self.apply_filter();
 
                     if verified {
-                        self.status = format!("Set .{} -> {}", ext, app_name);
+                        let mut status = format!("Set .{} -> {}", ext, app_name);
+                        if !siblings.is_empty() {
+                            let shown: Vec<String> =
+                                siblings.iter().take(3).map(|s| format!(".{s}")).collect();
+                            let extra = siblings.len().saturating_sub(3);
+                            let more = if extra > 0 {
+                                format!(" +{extra}")
+                            } else {
+                                String::new()
+                            };
+                            status.push_str(&format!(
+                                " (also affects {}{})",
+                                shown.join(", "),
+                                more
+                            ));
+                        }
+                        self.status = status;
                         self.status_kind = StatusKind::Success;
                         self.changes.push((ext, app_name));
                     } else {
@@ -535,12 +568,7 @@ fn load_data(phase: Arc<Mutex<LoadPhase>>, progress: Arc<AtomicUsize>) -> Result
         }
     };
 
-    let mut extensions: Vec<String> = apps
-        .iter()
-        .flat_map(|app| app.extensions.iter().map(|e| e.to_lowercase()))
-        .collect();
-    extensions.sort();
-    extensions.dedup();
+    let extensions = scanner::all_extensions(&apps);
 
     let total = extensions.len();
     *phase.lock().unwrap() = LoadPhase::Querying { total };

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -8,6 +8,9 @@ use super::{launchservices, listing, scanner, uti};
 #[derive(Serialize, Deserialize)]
 pub struct Config {
     pub associations: BTreeMap<String, String>,
+    /// URL scheme handlers (e.g. "http" -> "org.mozilla.firefox").
+    #[serde(default)]
+    pub schemes: BTreeMap<String, String>,
 }
 
 pub struct ImportResult {
@@ -36,7 +39,56 @@ pub fn export_associations(apps: &[AppInfo]) -> Result<(Config, BTreeMap<String,
         associations.insert(key, bundle_id);
     }
 
-    Ok((Config { associations }, display_names))
+    let schemes = export_schemes(apps, &mut display_names);
+
+    Ok((
+        Config {
+            associations,
+            schemes,
+        },
+        display_names,
+    ))
+}
+
+/// Export URL scheme handlers. Only schemes where a real choice exists are
+/// included: those declared by more than one installed app, plus the always
+/// contested web/mail schemes. Exporting every vanity scheme (slack://,
+/// spotify://, ...) would just be noise — the declaring app is the only
+/// possible handler.
+fn export_schemes(
+    apps: &[AppInfo],
+    display_names: &mut BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for app in apps {
+        for scheme in &app.url_schemes {
+            *counts.entry(scheme.to_lowercase()).or_default() += 1;
+        }
+    }
+
+    let mut candidates: std::collections::BTreeSet<String> = counts
+        .into_iter()
+        .filter(|(_, count)| *count >= 2)
+        .map(|(scheme, _)| scheme)
+        .collect();
+    for common in ["http", "https", "mailto"] {
+        candidates.insert(common.to_string());
+    }
+
+    let mut schemes = BTreeMap::new();
+    for scheme in candidates {
+        if let Some(bundle_id) = launchservices::query_default_scheme_handler(&scheme)
+            .ok()
+            .flatten()
+        {
+            let name = scanner::resolve_name(apps, &bundle_id);
+            if name != bundle_id {
+                display_names.insert(scheme.clone(), name);
+            }
+            schemes.insert(scheme, bundle_id);
+        }
+    }
+    schemes
 }
 
 /// Import associations from a Config, applying each one.
@@ -95,6 +147,46 @@ pub fn import_associations(config: &Config, apps: &[AppInfo], dry_run: bool) -> 
         }
     }
 
+    for (scheme_key, value) in &config.schemes {
+        let scheme = scheme_key.trim().to_lowercase();
+        let display_key = format!("{}://", scheme);
+
+        let (bundle_id, display_name) = match scanner::resolve_app_or_bundle_id(apps, value) {
+            Ok(pair) => pair,
+            Err(reason) => {
+                skipped.push((display_key, value.clone(), reason.to_string()));
+                continue;
+            }
+        };
+
+        let current = launchservices::query_default_scheme_handler(&scheme)
+            .ok()
+            .flatten();
+        if current
+            .as_deref()
+            .is_some_and(|c| c.eq_ignore_ascii_case(&bundle_id))
+        {
+            unchanged.push((display_key, display_name));
+            continue;
+        }
+
+        let previous = current.map(|c| scanner::resolve_name(apps, &c));
+
+        if dry_run {
+            applied.push((display_key, display_name, previous));
+            continue;
+        }
+
+        match launchservices::set_default_scheme_handler(&bundle_id, &scheme) {
+            Ok(_) => {
+                applied.push((display_key, display_name, previous));
+            }
+            Err(e) => {
+                skipped.push((display_key, display_name, e.to_string()));
+            }
+        }
+    }
+
     ImportResult {
         applied,
         unchanged,
@@ -113,11 +205,14 @@ pub fn to_toml(config: &Config, display_names: &BTreeMap<String, String>) -> Res
     ];
 
     for (ext, bundle_id) in &config.associations {
-        let escaped_key = format!("\"{}\"", ext);
-        let escaped_val = format!("\"{}\"", bundle_id);
-        match display_names.get(ext) {
-            Some(name) => lines.push(format!("{} = {}  # {}", escaped_key, escaped_val, name)),
-            None => lines.push(format!("{} = {}", escaped_key, escaped_val)),
+        lines.push(toml_line(ext, bundle_id, display_names.get(ext)));
+    }
+
+    if !config.schemes.is_empty() {
+        lines.push(String::new());
+        lines.push("[schemes]".to_string());
+        for (scheme, bundle_id) in &config.schemes {
+            lines.push(toml_line(scheme, bundle_id, display_names.get(scheme)));
         }
     }
 
@@ -125,7 +220,63 @@ pub fn to_toml(config: &Config, display_names: &BTreeMap<String, String>) -> Res
     Ok(lines.join("\n"))
 }
 
+fn toml_line(key: &str, value: &str, display_name: Option<&String>) -> String {
+    let escaped_key = format!("\"{}\"", key);
+    let escaped_val = format!("\"{}\"", value);
+    match display_name {
+        Some(name) => format!("{} = {}  # {}", escaped_key, escaped_val, name),
+        None => format!("{} = {}", escaped_key, escaped_val),
+    }
+}
+
 /// Deserialize a Config from a TOML string.
 pub fn from_toml(content: &str) -> Result<Config> {
     toml::from_str(content).context("failed to parse TOML config")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{from_toml, to_toml};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn toml_round_trip_preserves_associations_and_schemes() {
+        let input = r#"
+[associations]
+".md" = "abnerworks.Typora"
+
+[schemes]
+"http" = "org.mozilla.firefox"
+"#;
+
+        let config = from_toml(input).unwrap();
+        assert_eq!(
+            config.associations.get(".md").map(String::as_str),
+            Some("abnerworks.Typora")
+        );
+        assert_eq!(
+            config.schemes.get("http").map(String::as_str),
+            Some("org.mozilla.firefox")
+        );
+
+        let mut display_names = BTreeMap::new();
+        display_names.insert(".md".to_string(), "Typora".to_string());
+        display_names.insert("http".to_string(), "Firefox".to_string());
+
+        let out = to_toml(&config, &display_names).unwrap();
+        assert!(out.contains("[associations]"));
+        assert!(out.contains("\".md\" = \"abnerworks.Typora\"  # Typora"));
+        assert!(out.contains("[schemes]"));
+        assert!(out.contains("\"http\" = \"org.mozilla.firefox\"  # Firefox"));
+
+        let reparsed = from_toml(&out).unwrap();
+        assert_eq!(reparsed.associations, config.associations);
+        assert_eq!(reparsed.schemes, config.schemes);
+    }
+
+    #[test]
+    fn missing_schemes_table_defaults_to_empty() {
+        let config = from_toml("[associations]\n\".pdf\" = \"com.apple.Preview\"\n").unwrap();
+        assert!(config.schemes.is_empty());
+    }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -53,27 +53,9 @@ pub fn export_associations(apps: &[AppInfo]) -> Result<(Config, BTreeMap<String,
     ))
 }
 
-/// Resolve a config value to a bundle ID. If the value looks like a bundle ID
-/// (contains a dot), use it directly. Otherwise, resolve as a display name.
-fn resolve_bundle_id(value: &str, apps: &[AppInfo]) -> Result<(String, String), String> {
-    // Heuristic: bundle IDs contain dots (e.g. "com.apple.Preview")
-    // Display names generally don't (e.g. "Preview", "Visual Studio Code")
-    if value.contains('.') && !value.starts_with('.') {
-        // Looks like a bundle ID — use directly, resolve name for display
-        let name = scanner::resolve_name(apps, value);
-        return Ok((value.to_string(), name));
-    }
-
-    // Treat as display name
-    match scanner::resolve_app(apps, value) {
-        Ok(app) if !app.bundle_id.is_empty() => Ok((app.bundle_id.clone(), app.name.clone())),
-        Ok(app) => Err(format!("no bundle ID for '{}'", app.name)),
-        Err(e) => Err(e.to_string()),
-    }
-}
-
 /// Import associations from a Config, applying each one.
-/// Values can be bundle IDs or display names — both are accepted.
+/// Values can be bundle IDs or display names — both are accepted, and both
+/// must resolve to an installed app.
 pub fn import_associations(config: &Config, apps: &[AppInfo]) -> ImportResult {
     let mut applied = Vec::new();
     let mut skipped = Vec::new();
@@ -81,10 +63,10 @@ pub fn import_associations(config: &Config, apps: &[AppInfo]) -> ImportResult {
     for (ext_key, value) in &config.associations {
         let ext = ext_key.trim_start_matches('.');
 
-        let (bundle_id, display_name) = match resolve_bundle_id(value, apps) {
+        let (bundle_id, display_name) = match scanner::resolve_app_or_bundle_id(apps, value) {
             Ok(pair) => pair,
             Err(reason) => {
-                skipped.push((ext_key.clone(), value.clone(), reason));
+                skipped.push((ext_key.clone(), value.clone(), reason.to_string()));
                 continue;
             }
         };

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
 
 pub struct ImportResult {
     pub applied: Vec<(String, String)>,
+    pub unchanged: Vec<(String, String)>,
     pub skipped: Vec<(String, String, String)>,
 }
 
@@ -55,9 +56,12 @@ pub fn export_associations(apps: &[AppInfo]) -> Result<(Config, BTreeMap<String,
 
 /// Import associations from a Config, applying each one.
 /// Values can be bundle IDs or display names — both are accepted, and both
-/// must resolve to an installed app.
-pub fn import_associations(config: &Config, apps: &[AppInfo]) -> ImportResult {
+/// must resolve to an installed app. Associations already set correctly are
+/// left untouched, so import is idempotent. With `dry_run`, nothing is
+/// written and `applied` lists what would change.
+pub fn import_associations(config: &Config, apps: &[AppInfo], dry_run: bool) -> ImportResult {
     let mut applied = Vec::new();
+    let mut unchanged = Vec::new();
     let mut skipped = Vec::new();
 
     for (ext_key, value) in &config.associations {
@@ -79,6 +83,21 @@ pub fn import_associations(config: &Config, apps: &[AppInfo]) -> ImportResult {
             }
         };
 
+        // Leave associations that already match untouched.
+        let current = launchservices::query_default_bundle_id(ext).ok().flatten();
+        if current
+            .as_deref()
+            .is_some_and(|c| c.eq_ignore_ascii_case(&bundle_id))
+        {
+            unchanged.push((ext_key.clone(), display_name));
+            continue;
+        }
+
+        if dry_run {
+            applied.push((ext_key.clone(), display_name));
+            continue;
+        }
+
         match launchservices::set_default(&bundle_id, &uti_str) {
             Ok(_) => {
                 applied.push((ext_key.clone(), display_name));
@@ -89,7 +108,11 @@ pub fn import_associations(config: &Config, apps: &[AppInfo]) -> ImportResult {
         }
     }
 
-    ImportResult { applied, skipped }
+    ImportResult {
+        applied,
+        unchanged,
+        skipped,
+    }
 }
 
 /// Serialize a Config to TOML string with display name comments.

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -19,12 +19,7 @@ pub struct ImportResult {
 /// Export current file associations to a Config.
 /// Values are bundle IDs (canonical, lossless for round-tripping).
 pub fn export_associations(apps: &[AppInfo]) -> Result<(Config, BTreeMap<String, String>)> {
-    let mut extensions: Vec<String> = apps
-        .iter()
-        .flat_map(|app| app.extensions.iter().map(|e| e.to_lowercase()))
-        .collect();
-    extensions.sort();
-    extensions.dedup();
+    let extensions = scanner::all_extensions(apps);
 
     let associations: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
     let display_names: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -12,7 +12,8 @@ pub struct Config {
 }
 
 pub struct ImportResult {
-    pub applied: Vec<(String, String)>,
+    /// (extension key, new app name, previous app name if any)
+    pub applied: Vec<(String, String, Option<String>)>,
     pub unchanged: Vec<(String, String)>,
     pub skipped: Vec<(String, String, String)>,
 }
@@ -93,14 +94,16 @@ pub fn import_associations(config: &Config, apps: &[AppInfo], dry_run: bool) -> 
             continue;
         }
 
+        let previous = current.map(|c| scanner::resolve_name(apps, &c));
+
         if dry_run {
-            applied.push((ext_key.clone(), display_name));
+            applied.push((ext_key.clone(), display_name, previous));
             continue;
         }
 
         match launchservices::set_default(&bundle_id, &uti_str) {
             Ok(_) => {
-                applied.push((ext_key.clone(), display_name));
+                applied.push((ext_key.clone(), display_name, previous));
             }
             Err(e) => {
                 skipped.push((ext_key.clone(), display_name, e.to_string()));

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,10 +1,9 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::sync::Mutex;
 
 use super::types::AppInfo;
-use super::{launchservices, scanner, uti};
+use super::{launchservices, listing, scanner, uti};
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
@@ -21,38 +20,23 @@ pub struct ImportResult {
 /// Export current file associations to a Config.
 /// Values are bundle IDs (canonical, lossless for round-tripping).
 pub fn export_associations(apps: &[AppInfo]) -> Result<(Config, BTreeMap<String, String>)> {
-    let extensions = scanner::all_extensions(apps);
+    let mut associations = BTreeMap::new();
+    let mut display_names = BTreeMap::new();
 
-    let associations: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
-    let display_names: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
-
-    std::thread::scope(|s| {
-        for chunk in extensions.chunks(20) {
-            let associations = &associations;
-            let display_names = &display_names;
-            let chunk = chunk.to_vec();
-            s.spawn(move || {
-                for ext in chunk {
-                    if let Some(bid) = launchservices::query_default_bundle_id(&ext).ok().flatten()
-                    {
-                        let key = format!(".{}", ext);
-                        let name = scanner::resolve_name(apps, &bid);
-                        if name != bid {
-                            display_names.lock().unwrap().insert(key.clone(), name);
-                        }
-                        associations.lock().unwrap().insert(key, bid);
-                    }
-                }
-            });
+    for assoc in listing::query_all(apps, &|| {}) {
+        let Some(bundle_id) = assoc.bundle_id else {
+            continue;
+        };
+        let key = format!(".{}", assoc.ext);
+        if let Some(name) = assoc.app_name
+            && name != bundle_id
+        {
+            display_names.insert(key.clone(), name);
         }
-    });
+        associations.insert(key, bundle_id);
+    }
 
-    Ok((
-        Config {
-            associations: associations.into_inner().unwrap(),
-        },
-        display_names.into_inner().unwrap(),
-    ))
+    Ok((Config { associations }, display_names))
 }
 
 /// Import associations from a Config, applying each one.

--- a/src/core/launchservices.rs
+++ b/src/core/launchservices.rs
@@ -26,6 +26,13 @@ unsafe extern "C" {
         role: u32,
         handler_bundle_id: CFStringRef,
     ) -> OSStatus;
+
+    fn LSCopyDefaultHandlerForURLScheme(scheme: CFStringRef) -> CFStringRef;
+
+    fn LSSetDefaultHandlerForURLScheme(
+        scheme: CFStringRef,
+        handler_bundle_id: CFStringRef,
+    ) -> OSStatus;
 }
 
 /// Query the system for any UTI matching this extension, including dynamic UTIs.
@@ -88,6 +95,49 @@ fn query_default_for_uti(uti_str: &str) -> Result<Option<String>> {
     } else {
         Ok(Some(bundle_id))
     }
+}
+
+/// Query the default handler bundle ID for a URL scheme (e.g. "http").
+/// Returns `None` if no default is set.
+pub fn query_default_scheme_handler(scheme: &str) -> Result<Option<String>> {
+    let scheme_cf = CFString::new(scheme);
+    let result = unsafe { LSCopyDefaultHandlerForURLScheme(scheme_cf.as_concrete_TypeRef()) };
+
+    if result.is_null() {
+        return Ok(None);
+    }
+
+    let bundle_id = unsafe { CFString::wrap_under_create_rule(result) }.to_string();
+    if bundle_id.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(bundle_id))
+    }
+}
+
+/// Set the default handler for a URL scheme.
+pub fn set_default_scheme_handler(bundle_id: &str, scheme: &str) -> Result<()> {
+    let scheme_cf = CFString::new(scheme);
+    let bundle_cf = CFString::new(bundle_id);
+
+    let status = unsafe {
+        LSSetDefaultHandlerForURLScheme(
+            scheme_cf.as_concrete_TypeRef(),
+            bundle_cf.as_concrete_TypeRef(),
+        )
+    };
+
+    if status != 0 {
+        bail!(
+            "failed to set handler for {}:// (OSStatus {}). \
+             The bundle ID '{}' may be invalid or the app may not declare the scheme.",
+            scheme,
+            status,
+            bundle_id
+        );
+    }
+
+    Ok(())
 }
 
 /// Set the default application for a UTI.

--- a/src/core/listing.rs
+++ b/src/core/listing.rs
@@ -1,0 +1,44 @@
+use std::sync::Mutex;
+
+use super::types::AppInfo;
+use super::{launchservices, scanner};
+
+/// A file extension and its current default handler.
+#[derive(Clone)]
+pub struct Association {
+    pub ext: String,
+    pub app_name: Option<String>,
+    pub bundle_id: Option<String>,
+}
+
+/// Query the current default for every extension declared by the scanned
+/// apps, in parallel. `on_progress` is called once per completed extension.
+pub fn query_all(apps: &[AppInfo], on_progress: &(dyn Fn() + Sync)) -> Vec<Association> {
+    let extensions = scanner::all_extensions(apps);
+    let rows: Mutex<Vec<Association>> = Mutex::new(Vec::new());
+
+    std::thread::scope(|s| {
+        for chunk in extensions.chunks(20) {
+            let rows = &rows;
+            let chunk = chunk.to_vec();
+            s.spawn(move || {
+                for ext in chunk {
+                    let bundle_id = launchservices::query_default_bundle_id(&ext).ok().flatten();
+                    let app_name = bundle_id
+                        .as_ref()
+                        .map(|bid| scanner::resolve_name(apps, bid));
+                    rows.lock().unwrap().push(Association {
+                        ext,
+                        app_name,
+                        bundle_id,
+                    });
+                    on_progress();
+                }
+            });
+        }
+    });
+
+    let mut rows = rows.into_inner().unwrap();
+    rows.sort_by(|a, b| a.ext.cmp(&b.ext));
+    rows
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod launchservices;
+pub mod listing;
 pub mod plist;
 pub mod scanner;
 pub mod types;

--- a/src/core/plist.rs
+++ b/src/core/plist.rs
@@ -1,77 +1,71 @@
 use anyhow::Result;
-use std::collections::HashSet;
-use std::process::Command;
+use plist::Value;
+use std::collections::BTreeSet;
+use std::path::Path;
 
+/// Metadata extracted from an application's Info.plist.
 #[derive(Debug, Default)]
-pub struct DocumentTypes {
+pub struct BundleInfo {
+    pub bundle_id: Option<String>,
     pub extensions: Vec<String>,
     pub content_types: Vec<String>,
 }
 
-/// Parse an application's Info.plist document declarations.
-pub fn parse_document_types(plist_path: &str) -> Result<DocumentTypes> {
-    if !std::path::Path::new(plist_path).exists() {
-        return Ok(DocumentTypes::default());
+/// Parse an application's Info.plist (XML or binary).
+/// Missing or unreadable plists yield an empty `BundleInfo` so a single
+/// malformed app cannot abort a whole scan.
+pub fn parse_bundle_info(plist_path: &Path) -> Result<BundleInfo> {
+    match Value::from_file(plist_path) {
+        Ok(value) => Ok(bundle_info_from_value(&value)),
+        Err(_) => Ok(BundleInfo::default()),
     }
-
-    let output = Command::new("/usr/libexec/PlistBuddy")
-        .arg("-c")
-        .arg("Print :CFBundleDocumentTypes")
-        .arg(plist_path)
-        .output();
-
-    if let Ok(output) = output {
-        let content = String::from_utf8_lossy(&output.stdout);
-        return Ok(parse_document_types_output(&content));
-    }
-
-    Ok(DocumentTypes::default())
 }
 
-fn parse_document_types_output(content: &str) -> DocumentTypes {
-    let mut extensions = HashSet::new();
-    let mut content_types = HashSet::new();
-    let mut collecting = None;
+fn bundle_info_from_value(value: &Value) -> BundleInfo {
+    let Some(dict) = value.as_dictionary() else {
+        return BundleInfo::default();
+    };
 
-    for line in content.lines() {
-        let line = line.trim();
-        if line == "}" && collecting.is_some() {
-            collecting = None;
-            continue;
-        }
+    let bundle_id = dict
+        .get("CFBundleIdentifier")
+        .and_then(Value::as_string)
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
 
-        match collecting {
-            Some(DocumentTypeArray::Extensions) => {
-                insert_normalized(&mut extensions, line, true);
-                continue;
+    let mut extensions = BTreeSet::new();
+    let mut content_types = BTreeSet::new();
+    if let Some(doc_types) = dict.get("CFBundleDocumentTypes").and_then(Value::as_array) {
+        for doc_type in doc_types.iter().filter_map(Value::as_dictionary) {
+            for ext in string_array(doc_type.get("CFBundleTypeExtensions")) {
+                insert_normalized(&mut extensions, &ext, true);
             }
-            Some(DocumentTypeArray::ContentTypes) => {
-                insert_normalized(&mut content_types, line, false);
-                continue;
+            for content_type in string_array(doc_type.get("LSItemContentTypes")) {
+                insert_normalized(&mut content_types, &content_type, false);
             }
-            None => {}
         }
-
-        collecting = match line {
-            "CFBundleTypeExtensions = Array {" => Some(DocumentTypeArray::Extensions),
-            "LSItemContentTypes = Array {" => Some(DocumentTypeArray::ContentTypes),
-            _ => None,
-        };
     }
 
-    DocumentTypes {
-        extensions: sorted(extensions),
-        content_types: sorted(content_types),
+    BundleInfo {
+        bundle_id,
+        extensions: extensions.into_iter().collect(),
+        content_types: content_types.into_iter().collect(),
     }
 }
 
-#[derive(Clone, Copy)]
-enum DocumentTypeArray {
-    Extensions,
-    ContentTypes,
+fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|array| {
+            array
+                .iter()
+                .filter_map(Value::as_string)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
-fn insert_normalized(values: &mut HashSet<String>, value: &str, is_extension: bool) {
+fn insert_normalized(values: &mut BTreeSet<String>, value: &str, is_extension: bool) {
     let value = value.trim().to_lowercase();
     let value = if is_extension {
         value.trim_start_matches('.')
@@ -84,54 +78,101 @@ fn insert_normalized(values: &mut HashSet<String>, value: &str, is_extension: bo
     }
 }
 
-fn sorted(values: HashSet<String>) -> Vec<String> {
-    let mut result: Vec<String> = values.into_iter().collect();
-    result.sort();
-    result
-}
-
 #[cfg(test)]
 mod tests {
-    use super::parse_document_types_output;
+    use super::{BundleInfo, parse_bundle_info};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    #[test]
-    fn parses_legacy_bundle_type_extensions() {
-        let content = r#"
-Array {
-    Dict {
-        CFBundleTypeExtensions = Array {
-            md
-            markdown
-        }
-    }
-}
+    const FIXTURE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Editor</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>MD</string>
+                <string>.markdown</string>
+                <string>*</string>
+            </array>
+        </dict>
+        <dict>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.plain-text</string>
+                <string>public.JSON</string>
+            </array>
+        </dict>
+    </array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>editor</string>
+                <string>Editor-Beta</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>
 "#;
 
-        let document_types = parse_document_types_output(content);
+    fn temp_path(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("openwith-plist-test-{unique}-{name}"))
+    }
 
-        assert_eq!(document_types.extensions, vec!["markdown", "md"]);
-        assert!(document_types.content_types.is_empty());
+    fn parse_fixture(name: &str, content: &str) -> BundleInfo {
+        let path = temp_path(name);
+        fs::write(&path, content).unwrap();
+        let info = parse_bundle_info(&path).unwrap();
+        fs::remove_file(&path).unwrap();
+        info
     }
 
     #[test]
-    fn parses_ls_item_content_types_without_mapping_them() {
-        let content = r#"
-Array {
-    Dict {
-        LSItemContentTypes = Array {
-            public.jpeg
-            public.plain-text
-        }
+    fn parses_xml_plist_with_normalization() {
+        let info = parse_fixture("xml.plist", FIXTURE);
+
+        assert_eq!(info.bundle_id.as_deref(), Some("com.example.Editor"));
+        assert_eq!(info.extensions, vec!["markdown", "md"]);
+        assert_eq!(info.content_types, vec!["public.json", "public.plain-text"]);
     }
-}
-"#;
 
-        let document_types = parse_document_types_output(content);
+    #[test]
+    fn parses_binary_plist() {
+        let xml_path = temp_path("roundtrip-src.plist");
+        fs::write(&xml_path, FIXTURE).unwrap();
+        let value = plist::Value::from_file(&xml_path).unwrap();
+        fs::remove_file(&xml_path).unwrap();
 
-        assert!(document_types.extensions.is_empty());
-        assert_eq!(
-            document_types.content_types,
-            vec!["public.jpeg", "public.plain-text"]
-        );
+        let bin_path = temp_path("binary.plist");
+        value.to_file_binary(&bin_path).unwrap();
+        let info = parse_bundle_info(&bin_path).unwrap();
+        fs::remove_file(&bin_path).unwrap();
+
+        assert_eq!(info.bundle_id.as_deref(), Some("com.example.Editor"));
+        assert_eq!(info.extensions, vec!["markdown", "md"]);
+    }
+
+    #[test]
+    fn missing_or_invalid_plist_yields_empty_info() {
+        let missing = parse_bundle_info(&temp_path("does-not-exist.plist")).unwrap();
+        assert!(missing.bundle_id.is_none());
+        assert!(missing.extensions.is_empty());
+
+        let invalid = parse_fixture("invalid.plist", "not a plist at all");
+        assert!(invalid.bundle_id.is_none());
+        assert!(invalid.extensions.is_empty());
+        assert!(invalid.content_types.is_empty());
     }
 }

--- a/src/core/plist.rs
+++ b/src/core/plist.rs
@@ -9,6 +9,7 @@ pub struct BundleInfo {
     pub bundle_id: Option<String>,
     pub extensions: Vec<String>,
     pub content_types: Vec<String>,
+    pub url_schemes: Vec<String>,
 }
 
 /// Parse an application's Info.plist (XML or binary).
@@ -45,10 +46,20 @@ fn bundle_info_from_value(value: &Value) -> BundleInfo {
         }
     }
 
+    let mut url_schemes = BTreeSet::new();
+    if let Some(url_types) = dict.get("CFBundleURLTypes").and_then(Value::as_array) {
+        for url_type in url_types.iter().filter_map(Value::as_dictionary) {
+            for scheme in string_array(url_type.get("CFBundleURLSchemes")) {
+                insert_normalized(&mut url_schemes, &scheme, false);
+            }
+        }
+    }
+
     BundleInfo {
         bundle_id,
         extensions: extensions.into_iter().collect(),
         content_types: content_types.into_iter().collect(),
+        url_schemes: url_schemes.into_iter().collect(),
     }
 }
 
@@ -146,6 +157,7 @@ mod tests {
         assert_eq!(info.bundle_id.as_deref(), Some("com.example.Editor"));
         assert_eq!(info.extensions, vec!["markdown", "md"]);
         assert_eq!(info.content_types, vec!["public.json", "public.plain-text"]);
+        assert_eq!(info.url_schemes, vec!["editor", "editor-beta"]);
     }
 
     #[test]

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -78,6 +78,7 @@ pub fn scan_all_apps() -> Result<Vec<AppInfo>> {
             bundle_id: info.bundle_id.unwrap_or_default(),
             extensions: info.extensions,
             content_types: info.content_types,
+            url_schemes: info.url_schemes,
         });
     }
 
@@ -206,6 +207,7 @@ mod tests {
             bundle_id: bundle_id.to_string(),
             extensions: vec![],
             content_types: vec![],
+            url_schemes: vec![],
         }
     }
 
@@ -303,12 +305,14 @@ mod tests {
             bundle_id: "example.broad-text".to_string(),
             extensions: vec![],
             content_types: vec!["public.text".to_string()],
+            url_schemes: vec![],
         };
         let markdown_app = AppInfo {
             name: "Markdown App".to_string(),
             bundle_id: "example.markdown".to_string(),
             extensions: vec![],
             content_types: vec!["net.daringfireball.markdown".to_string()],
+            url_schemes: vec![],
         };
 
         assert!(!super::app_supports_extension(&broad_text_app, "md"));

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -59,23 +59,6 @@ fn collect_app_paths_from_dir(dir: &Path, max_depth: usize, app_paths: &mut Vec<
     }
 }
 
-/// Read CFBundleIdentifier from an app's Info.plist via PlistBuddy.
-fn read_bundle_id_from_plist(plist_path: &str) -> Option<String> {
-    let output = Command::new("/usr/libexec/PlistBuddy")
-        .arg("-c")
-        .arg("Print :CFBundleIdentifier")
-        .arg(plist_path)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if id.is_empty() { None } else { Some(id) }
-}
-
 /// Scan all apps and build AppInfo structs with extensions and bundle IDs.
 pub fn scan_all_apps() -> Result<Vec<AppInfo>> {
     let paths = scan_app_paths()?;
@@ -87,15 +70,14 @@ pub fn scan_all_apps() -> Result<Vec<AppInfo>> {
             None => continue,
         };
 
-        let info_plist = format!("{}/Contents/Info.plist", app_path);
-        let document_types = plist::parse_document_types(&info_plist).unwrap_or_default();
-        let bundle_id = read_bundle_id_from_plist(&info_plist).unwrap_or_default();
+        let info_plist = Path::new(app_path).join("Contents/Info.plist");
+        let info = plist::parse_bundle_info(&info_plist).unwrap_or_default();
 
         apps.push(AppInfo {
             name,
-            bundle_id,
-            extensions: document_types.extensions,
-            content_types: document_types.content_types,
+            bundle_id: info.bundle_id.unwrap_or_default(),
+            extensions: info.extensions,
+            content_types: info.content_types,
         });
     }
 

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -141,6 +141,31 @@ pub fn resolve_app<'a>(apps: &'a [AppInfo], app_name: &str) -> Result<&'a AppInf
     }
 }
 
+/// Resolve a user-supplied value — an app name or a bundle ID — to a
+/// `(bundle_id, display_name)` pair.
+///
+/// Exact bundle ID matches win (e.g. "com.apple.Preview"); anything else is
+/// resolved as an app name via `resolve_app`.
+pub fn resolve_app_or_bundle_id(apps: &[AppInfo], value: &str) -> Result<(String, String)> {
+    let search = value.trim();
+    if search.is_empty() {
+        bail!("app name cannot be empty");
+    }
+
+    if let Some(app) = apps
+        .iter()
+        .find(|a| !a.bundle_id.is_empty() && a.bundle_id.eq_ignore_ascii_case(search))
+    {
+        return Ok((app.bundle_id.clone(), app.name.clone()));
+    }
+
+    match resolve_app(apps, search) {
+        Ok(app) if !app.bundle_id.is_empty() => Ok((app.bundle_id.clone(), app.name.clone())),
+        Ok(app) => bail!("could not determine bundle ID for '{}'", app.name),
+        Err(err) => Err(err),
+    }
+}
+
 /// Resolve a bundle ID to an app name. Falls back to the raw bundle ID.
 pub fn resolve_name(apps: &[AppInfo], bundle_id: &str) -> String {
     apps.iter()
@@ -170,7 +195,7 @@ fn ambiguous_app_message(search: &str, matches: &[&AppInfo]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_app_paths_from_dir, resolve_app};
+    use super::{collect_app_paths_from_dir, resolve_app, resolve_app_or_bundle_id};
     use crate::core::types::AppInfo;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -206,6 +231,37 @@ mod tests {
         let resolved = resolve_app(&apps, "prev").unwrap();
 
         assert_eq!(resolved.bundle_id, "com.apple.Preview");
+    }
+
+    #[test]
+    fn resolve_app_or_bundle_id_accepts_exact_bundle_id() {
+        let apps = vec![
+            app("Preview", "com.apple.Preview"),
+            app("Skim", "net.sourceforge.skim-app.skim"),
+        ];
+
+        let (bundle_id, name) = resolve_app_or_bundle_id(&apps, "com.apple.preview").unwrap();
+
+        assert_eq!(bundle_id, "com.apple.Preview");
+        assert_eq!(name, "Preview");
+    }
+
+    #[test]
+    fn resolve_app_or_bundle_id_accepts_app_name() {
+        let apps = vec![app("Preview", "com.apple.Preview")];
+
+        let (bundle_id, name) = resolve_app_or_bundle_id(&apps, "prev").unwrap();
+
+        assert_eq!(bundle_id, "com.apple.Preview");
+        assert_eq!(name, "Preview");
+    }
+
+    #[test]
+    fn resolve_app_or_bundle_id_rejects_unknown_values() {
+        let apps = vec![app("Preview", "com.apple.Preview")];
+
+        assert!(resolve_app_or_bundle_id(&apps, "com.example.NotInstalled").is_err());
+        assert!(resolve_app_or_bundle_id(&apps, "  ").is_err());
     }
 
     #[test]

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -84,6 +84,17 @@ pub fn scan_all_apps() -> Result<Vec<AppInfo>> {
     Ok(apps)
 }
 
+/// All extensions declared by the scanned apps, lowercased and deduplicated.
+pub fn all_extensions(apps: &[AppInfo]) -> Vec<String> {
+    let mut extensions: Vec<String> = apps
+        .iter()
+        .flat_map(|app| app.extensions.iter().map(|e| e.to_lowercase()))
+        .collect();
+    extensions.sort();
+    extensions.dedup();
+    extensions
+}
+
 pub fn app_supports_extension(app: &AppInfo, ext: &str) -> bool {
     let ext = ext.trim_start_matches('.');
     if app.extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)) {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -5,4 +5,5 @@ pub struct AppInfo {
     pub bundle_id: String,
     pub extensions: Vec<String>,
     pub content_types: Vec<String>,
+    pub url_schemes: Vec<String>,
 }

--- a/src/core/uti.rs
+++ b/src/core/uti.rs
@@ -1,6 +1,8 @@
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow};
 use core_foundation::base::TCFType;
 use core_foundation::string::{CFString, CFStringRef};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 #[link(name = "CoreServices", kind = "framework")]
 unsafe extern "C" {
@@ -24,13 +26,17 @@ unsafe extern "C" {
 pub fn uti_for_extension(ext: &str) -> Result<String> {
     let ext = ext.trim_start_matches('.').to_lowercase();
 
-    match system_uti(&ext) {
-        Ok(uti) => Ok(uti),
-        Err(err) => match hardcoded_uti(&ext) {
-            Some(uti) => Ok(uti.to_string()),
-            None => Err(err),
-        },
+    if let Some(cached) = extension_cache().lock().unwrap().get(&ext) {
+        return cached.clone().ok_or_else(|| unrecognized_extension(&ext));
     }
+
+    let resolved = system_uti(&ext).or_else(|| hardcoded_uti(&ext).map(str::to_string));
+    extension_cache()
+        .lock()
+        .unwrap()
+        .insert(ext.clone(), resolved.clone());
+
+    resolved.ok_or_else(|| unrecognized_extension(&ext))
 }
 
 pub fn conforms_to(uti: &str, parent_uti: &str) -> bool {
@@ -38,12 +44,40 @@ pub fn conforms_to(uti: &str, parent_uti: &str) -> bool {
         return true;
     }
 
-    let uti = CFString::new(uti);
-    let parent_uti = CFString::new(parent_uti);
-    unsafe { UTTypeConformsTo(uti.as_concrete_TypeRef(), parent_uti.as_concrete_TypeRef()) }
+    let key = (uti.to_string(), parent_uti.to_string());
+    if let Some(&cached) = conformance_cache().lock().unwrap().get(&key) {
+        return cached;
+    }
+
+    let uti_cf = CFString::new(uti);
+    let parent_cf = CFString::new(parent_uti);
+    let result = unsafe {
+        UTTypeConformsTo(
+            uti_cf.as_concrete_TypeRef(),
+            parent_cf.as_concrete_TypeRef(),
+        )
+    };
+
+    conformance_cache().lock().unwrap().insert(key, result);
+    result
 }
 
-fn system_uti(ext: &str) -> Result<String> {
+/// Cache for extension -> UTI lookups; `None` records unresolvable extensions.
+fn extension_cache() -> &'static Mutex<HashMap<String, Option<String>>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Option<String>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn conformance_cache() -> &'static Mutex<HashMap<(String, String), bool>> {
+    static CACHE: OnceLock<Mutex<HashMap<(String, String), bool>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn unrecognized_extension(ext: &str) -> anyhow::Error {
+    anyhow!("extension .{} is not recognized by macOS", ext)
+}
+
+fn system_uti(ext: &str) -> Option<String> {
     let extension = CFString::new(ext);
     let uti_ref = unsafe {
         UTTypeCreatePreferredIdentifierForTag(
@@ -54,15 +88,15 @@ fn system_uti(ext: &str) -> Result<String> {
     };
 
     if uti_ref.is_null() {
-        bail!("extension .{} is not recognized by macOS", ext);
+        return None;
     }
 
     let uti = unsafe { CFString::wrap_under_create_rule(uti_ref) }.to_string();
     if uti.is_empty() || uti.starts_with("dyn.") {
-        bail!("extension .{} is not recognized by macOS", ext);
+        None
+    } else {
+        Some(uti)
     }
-
-    Ok(uti)
 }
 
 fn hardcoded_uti(ext: &str) -> Option<&'static str> {

--- a/src/core/uti.rs
+++ b/src/core/uti.rs
@@ -62,6 +62,60 @@ pub fn conforms_to(uti: &str, parent_uti: &str) -> bool {
     result
 }
 
+/// Extensions other than `ext` that resolve to the same UTI.
+///
+/// Launch Services associates default handlers with UTIs, not extensions, so
+/// changing the default for `ext` also changes it for every sibling returned
+/// here. Candidates are the hardcoded map plus `extra_candidates` (typically
+/// every extension declared by an installed app).
+pub fn extensions_sharing_uti(ext: &str, uti: &str, extra_candidates: &[String]) -> Vec<String> {
+    let ext = ext.trim_start_matches('.').to_lowercase();
+    let mut siblings = std::collections::BTreeSet::new();
+
+    let known = HARDCODED_UTIS.iter().map(|(e, _)| (*e).to_string());
+    let extra = extra_candidates
+        .iter()
+        .map(|c| c.trim_start_matches('.').to_lowercase());
+
+    for candidate in known.chain(extra) {
+        if candidate == ext {
+            continue;
+        }
+        if let Ok(candidate_uti) = uti_for_extension(&candidate)
+            && candidate_uti.eq_ignore_ascii_case(uti)
+        {
+            siblings.insert(candidate);
+        }
+    }
+
+    siblings.into_iter().collect()
+}
+
+/// Human-readable warning for a change that affects sibling extensions.
+/// Returns `None` when no other extensions share the UTI.
+pub fn shared_uti_note(ext: &str, uti: &str, siblings: &[String]) -> Option<String> {
+    if siblings.is_empty() {
+        return None;
+    }
+
+    const MAX_SHOWN: usize = 6;
+    let mut shown: Vec<String> = siblings
+        .iter()
+        .take(MAX_SHOWN)
+        .map(|s| format!(".{s}"))
+        .collect();
+    if siblings.len() > MAX_SHOWN {
+        shown.push(format!("and {} more", siblings.len() - MAX_SHOWN));
+    }
+
+    Some(format!(
+        ".{} shares its type ({}) with {}; this change affects them too",
+        ext.trim_start_matches('.'),
+        uti,
+        shown.join(", ")
+    ))
+}
+
 /// Cache for extension -> UTI lookups; `None` records unresolvable extensions.
 fn extension_cache() -> &'static Mutex<HashMap<String, Option<String>>> {
     static CACHE: OnceLock<Mutex<HashMap<String, Option<String>>>> = OnceLock::new();
@@ -99,122 +153,128 @@ fn system_uti(ext: &str) -> Option<String> {
     }
 }
 
+/// Fallback map for extensions the system resolves to a dynamic UTI.
+const HARDCODED_UTIS: &[(&str, &str)] = &[
+    // Text / markup
+    ("txt", "public.plain-text"),
+    ("rtf", "public.rtf"),
+    ("md", "net.daringfireball.markdown"),
+    ("markdown", "net.daringfireball.markdown"),
+    ("log", "public.log"),
+    ("csv", "public.comma-separated-values-text"),
+    ("tsv", "public.tab-separated-values-text"),
+    // Web
+    ("html", "public.html"),
+    ("htm", "public.html"),
+    ("css", "public.css"),
+    ("js", "com.netscape.javascript-source"),
+    ("json", "public.json"),
+    ("xml", "public.xml"),
+    ("svg", "public.svg-image"),
+    // Programming languages
+    ("rs", "org.rust-lang.rust-source"),
+    ("py", "public.python-script"),
+    ("rb", "public.ruby-script"),
+    ("go", "org.golang.go-source"),
+    ("java", "com.sun.java-source"),
+    ("c", "public.c-source"),
+    ("cpp", "public.c-plus-plus-source"),
+    ("cc", "public.c-plus-plus-source"),
+    ("cxx", "public.c-plus-plus-source"),
+    ("h", "public.c-header"),
+    ("hpp", "public.c-plus-plus-header"),
+    ("swift", "public.swift-source"),
+    ("m", "public.objective-c-source"),
+    ("ts", "org.typescriptlang.typescript"),
+    ("tsx", "org.typescriptlang.typescriptx"),
+    ("jsx", "org.reactjs.jsx"),
+    ("sh", "public.shell-script"),
+    ("bash", "public.shell-script"),
+    ("zsh", "public.shell-script"),
+    ("pl", "public.perl-script"),
+    ("php", "public.php-script"),
+    ("lua", "org.lua.lua-source"),
+    ("r", "org.r-project.r-source"),
+    ("sql", "public.sql"),
+    // Config / data
+    ("yaml", "public.yaml"),
+    ("yml", "public.yaml"),
+    ("toml", "public.toml"),
+    ("ini", "public.ini"),
+    ("cfg", "public.ini"),
+    ("plist", "com.apple.property-list"),
+    ("env", "public.plain-text"),
+    // Documents
+    ("pdf", "com.adobe.pdf"),
+    ("doc", "com.microsoft.word.doc"),
+    ("docx", "org.openxmlformats.wordprocessingml.document"),
+    ("xls", "com.microsoft.excel.xls"),
+    ("xlsx", "org.openxmlformats.spreadsheetml.sheet"),
+    ("ppt", "com.microsoft.powerpoint.ppt"),
+    ("pptx", "org.openxmlformats.presentationml.presentation"),
+    ("pages", "com.apple.iwork.pages.sffpages"),
+    ("numbers", "com.apple.iwork.numbers.sffnumbers"),
+    ("keynote", "com.apple.iwork.keynote.sffkey"),
+    // Images
+    ("jpg", "public.jpeg"),
+    ("jpeg", "public.jpeg"),
+    ("png", "public.png"),
+    ("gif", "com.compuserve.gif"),
+    ("bmp", "com.microsoft.bmp"),
+    ("tiff", "public.tiff"),
+    ("tif", "public.tiff"),
+    ("webp", "public.webp"),
+    ("ico", "com.microsoft.ico"),
+    ("heic", "public.heic"),
+    ("heif", "public.heic"),
+    ("raw", "public.camera-raw-image"),
+    ("psd", "com.adobe.photoshop-image"),
+    // Audio
+    ("mp3", "public.mp3"),
+    ("wav", "com.microsoft.waveform-audio"),
+    ("aac", "public.aac-audio"),
+    ("flac", "org.xiph.flac"),
+    ("ogg", "org.xiph.ogg-vorbis"),
+    ("m4a", "com.apple.m4a-audio"),
+    ("aiff", "public.aiff-audio"),
+    ("aif", "public.aiff-audio"),
+    ("wma", "com.microsoft.windows-media-wma"),
+    // Video
+    ("mp4", "public.mpeg-4"),
+    ("m4v", "com.apple.m4v-video"),
+    ("mov", "com.apple.quicktime-movie"),
+    ("avi", "public.avi"),
+    ("mkv", "org.matroska.mkv"),
+    ("webm", "org.webmproject.webm"),
+    ("wmv", "com.microsoft.windows-media-wmv"),
+    ("flv", "com.adobe.flash-video"),
+    // Archives
+    ("zip", "public.zip-archive"),
+    ("tar", "public.tar-archive"),
+    ("gz", "org.gnu.gnu-zip-archive"),
+    ("gzip", "org.gnu.gnu-zip-archive"),
+    ("bz2", "public.bzip2-archive"),
+    ("xz", "org.tukaani.xz-archive"),
+    ("7z", "org.7-zip.7-zip-archive"),
+    ("rar", "com.rarlab.rar-archive"),
+    ("dmg", "com.apple.disk-image-udif"),
+    ("iso", "public.iso-image"),
+    // Fonts
+    ("ttf", "public.truetype-ttf-font"),
+    ("otf", "public.opentype-font"),
+    ("woff", "org.w3c.woff"),
+    ("woff2", "org.w3c.woff2"),
+];
+
 fn hardcoded_uti(ext: &str) -> Option<&'static str> {
-    let uti = match ext {
-        // Text / markup
-        "txt" => "public.plain-text",
-        "rtf" => "public.rtf",
-        "md" | "markdown" => "net.daringfireball.markdown",
-        "log" => "public.log",
-        "csv" => "public.comma-separated-values-text",
-        "tsv" => "public.tab-separated-values-text",
-
-        // Web
-        "html" | "htm" => "public.html",
-        "css" => "public.css",
-        "js" => "com.netscape.javascript-source",
-        "json" => "public.json",
-        "xml" => "public.xml",
-        "svg" => "public.svg-image",
-
-        // Programming languages
-        "rs" => "org.rust-lang.rust-source",
-        "py" => "public.python-script",
-        "rb" => "public.ruby-script",
-        "go" => "org.golang.go-source",
-        "java" => "com.sun.java-source",
-        "c" => "public.c-source",
-        "cpp" | "cc" | "cxx" => "public.c-plus-plus-source",
-        "h" => "public.c-header",
-        "hpp" => "public.c-plus-plus-header",
-        "swift" => "public.swift-source",
-        "m" => "public.objective-c-source",
-        "ts" => "org.typescriptlang.typescript",
-        "tsx" => "org.typescriptlang.typescriptx",
-        "jsx" => "org.reactjs.jsx",
-        "sh" | "bash" | "zsh" => "public.shell-script",
-        "pl" => "public.perl-script",
-        "php" => "public.php-script",
-        "lua" => "org.lua.lua-source",
-        "r" => "org.r-project.r-source",
-        "sql" => "public.sql",
-
-        // Config / data
-        "yaml" | "yml" => "public.yaml",
-        "toml" => "public.toml",
-        "ini" | "cfg" => "public.ini",
-        "plist" => "com.apple.property-list",
-        "env" => "public.plain-text",
-
-        // Documents
-        "pdf" => "com.adobe.pdf",
-        "doc" => "com.microsoft.word.doc",
-        "docx" => "org.openxmlformats.wordprocessingml.document",
-        "xls" => "com.microsoft.excel.xls",
-        "xlsx" => "org.openxmlformats.spreadsheetml.sheet",
-        "ppt" => "com.microsoft.powerpoint.ppt",
-        "pptx" => "org.openxmlformats.presentationml.presentation",
-        "pages" => "com.apple.iwork.pages.sffpages",
-        "numbers" => "com.apple.iwork.numbers.sffnumbers",
-        "keynote" => "com.apple.iwork.keynote.sffkey",
-
-        // Images
-        "jpg" | "jpeg" => "public.jpeg",
-        "png" => "public.png",
-        "gif" => "com.compuserve.gif",
-        "bmp" => "com.microsoft.bmp",
-        "tiff" | "tif" => "public.tiff",
-        "webp" => "public.webp",
-        "ico" => "com.microsoft.ico",
-        "heic" | "heif" => "public.heic",
-        "raw" => "public.camera-raw-image",
-        "psd" => "com.adobe.photoshop-image",
-
-        // Audio
-        "mp3" => "public.mp3",
-        "wav" => "com.microsoft.waveform-audio",
-        "aac" => "public.aac-audio",
-        "flac" => "org.xiph.flac",
-        "ogg" => "org.xiph.ogg-vorbis",
-        "m4a" => "com.apple.m4a-audio",
-        "aiff" | "aif" => "public.aiff-audio",
-        "wma" => "com.microsoft.windows-media-wma",
-
-        // Video
-        "mp4" => "public.mpeg-4",
-        "m4v" => "com.apple.m4v-video",
-        "mov" => "com.apple.quicktime-movie",
-        "avi" => "public.avi",
-        "mkv" => "org.matroska.mkv",
-        "webm" => "org.webmproject.webm",
-        "wmv" => "com.microsoft.windows-media-wmv",
-        "flv" => "com.adobe.flash-video",
-
-        // Archives
-        "zip" => "public.zip-archive",
-        "tar" => "public.tar-archive",
-        "gz" | "gzip" => "org.gnu.gnu-zip-archive",
-        "bz2" => "public.bzip2-archive",
-        "xz" => "org.tukaani.xz-archive",
-        "7z" => "org.7-zip.7-zip-archive",
-        "rar" => "com.rarlab.rar-archive",
-        "dmg" => "com.apple.disk-image-udif",
-        "iso" => "public.iso-image",
-
-        // Fonts
-        "ttf" => "public.truetype-ttf-font",
-        "otf" => "public.opentype-font",
-        "woff" => "org.w3c.woff",
-        "woff2" => "org.w3c.woff2",
-
-        _ => return None,
-    };
-    Some(uti)
+    HARDCODED_UTIS
+        .iter()
+        .find(|(known, _)| *known == ext)
+        .map(|(_, uti)| *uti)
 }
-
 #[cfg(test)]
 mod tests {
-    use super::uti_for_extension;
+    use super::{extensions_sharing_uti, shared_uti_note, uti_for_extension};
 
     #[test]
     fn resolves_common_types() {
@@ -229,5 +289,27 @@ mod tests {
             .to_string();
 
         assert!(err.contains("not recognized by macOS"));
+    }
+
+    #[test]
+    fn finds_extensions_sharing_a_uti() {
+        let siblings = extensions_sharing_uti("env", "public.plain-text", &[]);
+
+        assert!(siblings.contains(&"txt".to_string()));
+        assert!(!siblings.contains(&"env".to_string()));
+    }
+
+    #[test]
+    fn shared_uti_note_lists_siblings_and_truncates() {
+        assert_eq!(shared_uti_note("env", "public.plain-text", &[]), None);
+
+        let note = shared_uti_note("env", "public.plain-text", &["txt".to_string()]).unwrap();
+        assert!(note.contains(".env"));
+        assert!(note.contains(".txt"));
+        assert!(note.contains("public.plain-text"));
+
+        let many: Vec<String> = (0..9).map(|i| format!("ext{i}")).collect();
+        let note = shared_uti_note("env", "public.plain-text", &many).unwrap();
+        assert!(note.contains("and 3 more"));
     }
 }

--- a/src/core/uti.rs
+++ b/src/core/uti.rs
@@ -16,15 +16,21 @@ unsafe extern "C" {
 }
 
 /// Resolve the UTI for a file extension.
-/// Uses a hardcoded map for common types, then asks macOS for known extensions.
+///
+/// Asks Launch Services first: apps can register their own UTIs, and the
+/// system mapping is what Finder actually consults, so writing a handler to
+/// any other UTI would silently have no effect. The hardcoded map is only a
+/// fallback for extensions the system maps to a dynamic (`dyn.*`) type.
 pub fn uti_for_extension(ext: &str) -> Result<String> {
     let ext = ext.trim_start_matches('.').to_lowercase();
 
-    if let Some(uti) = hardcoded_uti(&ext) {
-        return Ok(uti.to_string());
+    match system_uti(&ext) {
+        Ok(uti) => Ok(uti),
+        Err(err) => match hardcoded_uti(&ext) {
+            Some(uti) => Ok(uti.to_string()),
+            None => Err(err),
+        },
     }
-
-    system_uti(&ext)
 }
 
 pub fn conforms_to(uti: &str, parent_uti: &str) -> bool {
@@ -141,7 +147,8 @@ fn hardcoded_uti(ext: &str) -> Option<&'static str> {
         "wma" => "com.microsoft.windows-media-wma",
 
         // Video
-        "mp4" | "m4v" => "public.mpeg-4",
+        "mp4" => "public.mpeg-4",
+        "m4v" => "com.apple.m4v-video",
         "mov" => "com.apple.quicktime-movie",
         "avi" => "public.avi",
         "mkv" => "org.matroska.mkv",
@@ -176,8 +183,9 @@ mod tests {
     use super::uti_for_extension;
 
     #[test]
-    fn returns_hardcoded_uti_for_common_types() {
+    fn resolves_common_types() {
         assert_eq!(uti_for_extension("txt").unwrap(), "public.plain-text");
+        assert_eq!(uti_for_extension(".PDF").unwrap(), "com.adobe.pdf");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,15 @@ fn main() -> Result<()> {
         Some(cli::Commands::Import { path, dry_run }) => {
             commands::import::run(&path, dry_run)?;
         }
+        Some(cli::Commands::Completions { shell }) => {
+            use clap::CommandFactory;
+            let mut cmd = cli::Cli::command();
+            clap_complete::generate(shell, &mut cmd, "openwith", &mut std::io::stdout());
+        }
+        Some(cli::Commands::Mangen) => {
+            use clap::CommandFactory;
+            clap_mangen::Man::new(cli::Cli::command()).render(&mut std::io::stdout())?;
+        }
         None => {
             commands::list::run(false, false)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ fn main() -> Result<()> {
         Some(cli::Commands::List { plain, json }) => {
             commands::list::run(plain, json)?;
         }
-        Some(cli::Commands::Current { ext, json }) => {
-            commands::current::run(&ext, json)?;
+        Some(cli::Commands::Current { ext, json, scheme }) => {
+            commands::current::run(&ext, json, scheme)?;
         }
-        Some(cli::Commands::Set { ext, app }) => {
-            commands::set::run(&ext, &app)?;
+        Some(cli::Commands::Set { ext, app, scheme }) => {
+            commands::set::run(&ext, &app, scheme)?;
         }
         Some(cli::Commands::Apps) => {
             commands::tui::run(commands::tui::InitialView::Apps)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ fn main() -> Result<()> {
         Some(cli::Commands::Export { output }) => {
             commands::export::run(output.as_deref())?;
         }
-        Some(cli::Commands::Import { path }) => {
-            commands::import::run(&path)?;
+        Some(cli::Commands::Import { path, dry_run }) => {
+            commands::import::run(&path, dry_run)?;
         }
         None => {
             commands::tui::run(commands::tui::InitialView::Extensions)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,16 +8,16 @@ fn main() -> Result<()> {
     let args = cli::Cli::parse_with_help();
 
     match args.command {
-        Some(cli::Commands::List { .. }) => {
-            commands::tui::run(commands::tui::InitialView::Extensions)?;
+        Some(cli::Commands::List { plain, json }) => {
+            commands::list::run(plain, json)?;
         }
-        Some(cli::Commands::Current { ext }) => {
-            commands::current::run(&ext)?;
+        Some(cli::Commands::Current { ext, json }) => {
+            commands::current::run(&ext, json)?;
         }
         Some(cli::Commands::Set { ext, app }) => {
             commands::set::run(&ext, &app)?;
         }
-        Some(cli::Commands::Apps { .. }) => {
+        Some(cli::Commands::Apps) => {
             commands::tui::run(commands::tui::InitialView::Apps)?;
         }
         Some(cli::Commands::Export { output }) => {
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
             commands::import::run(&path, dry_run)?;
         }
         None => {
-            commands::tui::run(commands::tui::InitialView::Extensions)?;
+            commands::list::run(false, false)?;
         }
     }
 


### PR DESCRIPTION
# release: v0.4.0 — correctness, scriptability, and URL scheme support

A maintenance release implementing the full code review of the v0.3.2 codebase: correctness fixes around how macOS actually maps extensions to handlers, robustness and performance work, scriptable output, and URL scheme (default browser / mail client) management.

## Fixes

- **UTI resolution asks the system first.** The hardcoded map could disagree with Launch Services, making `set` write a handler to a UTI Finder never consults — the change silently had no effect. The map is now only a fallback for `dyn.*` types. (`m4v` also corrected to `com.apple.m4v-video`.)
- **Shared-UTI changes are surfaced.** Setting `.env` (→ `public.plain-text`) also changes `.txt` and friends; `set`, `import`, and the TUI now warn and list the affected sibling extensions, and the TUI updates the sibling rows immediately.
- **Import validates bundle IDs.** Dotted values were passed straight to Launch Services even for apps that aren't installed, leaving broken associations. Both names and bundle IDs must now resolve to an installed app; otherwise the entry is skipped with a reason — as the README always promised.
- **The TUI restores the terminal on panic** via an RAII guard + panic hook, instead of stranding the shell in raw mode on the alternate screen.

## Features

- `openwith set` accepts bundle IDs (`openwith set md abnerworks.Typora`).
- Idempotent import with `--dry-run`: already-correct associations are left untouched; the preview shows exactly what would change.
- Every change reports the previous handler (`Set .md -> Typora (was: Preview)`), and `set` skips the write when the target is already the default.
- Scriptable output: `openwith list` prints a plain table when piped, `--plain`/`--json` force a format, `current --json` includes the supporting-apps list.
- URL scheme handlers: `openwith current -s http`, `openwith set -s http Firefox`, plus a `[schemes]` table in export/import (only schemes with more than one candidate handler are exported, plus http/https/mailto).
- Shell completions (`openwith completions <shell>`) and a man page (`openwith mangen`).

## Changes

- Info.plist parsing moved from ~2 `PlistBuddy` subprocess spawns per app to the `plist` crate (XML + binary, one pass) — scans are dramatically faster and the parser is no longer a hand-rolled text scraper. PlistBuddy is no longer a runtime dependency.
- UTI lookups and conformance checks are memoized process-wide, collapsing the O(apps × extensions) FFI storm when building the TUI apps browser.
- CI now runs `cargo test` (the suite previously never ran in CI); new fixture-based tests cover plist parsing, resolver paths, shared-UTI detection, and TOML round-tripping with schemes.
- `CLAUDE.md` checked in with the project's build/architecture/release conventions.

## Validation

- `cargo fmt --check`, `cargo check`, and `cargo clippy --all-targets --all-features -- -D warnings` pass (cross-checked against the `aarch64-apple-darwin` target); `cargo test` runs on the macOS CI runner.
- Development was done in a Linux environment, so please smoke-test on a real Mac before tagging:
  - [x] TUI: both tabs, filtering, app picker, a `set` from the picker (status should show `(was …)` and `(also affects …)` where applicable)
  - [x] `openwith set md Typora` and `openwith set md abnerworks.Typora` (bundle ID)
  - [x] `openwith set env "Visual Studio Code"` → shared-UTI note listing `.txt` etc.
  - [x] `openwith current pdf --json`, `openwith list | head`, `openwith list --json | jq length`
  - [x] `openwith export -o t.toml` → edit → `openwith import --dry-run t.toml` → `openwith import t.toml` (second run should report everything unchanged)
  - [x] `openwith current -s http`, `openwith set -s http Safari` (and back)
  - [x] `openwith completions zsh | head`, `openwith mangen | man -l -` 

---

## Draft release notes for v0.4.0 (paste into `gh release create v0.4.0`)

```markdown
Correctness, scriptability, and URL scheme support — openwith now changes exactly what it says it changes, and plays nicely in scripts.

**Features**
- Manage URL scheme handlers: `openwith set -s http Firefox`, `openwith current -s http`, and a `[schemes]` table in export/import
- Scriptable output: `openwith list` prints a plain table when piped; `--plain`/`--json` on `list` and `--json` on `current`
- `openwith set` accepts bundle IDs as well as app names
- Idempotent import with `--dry-run` preview; unchanged associations are left untouched
- Every change reports the previous handler (`Set .md -> Typora (was: Preview)`)
- Shell completions (`openwith completions <shell>`) and a man page

**Changes**
- Much faster scanning: Info.plist files are parsed natively (no more PlistBuddy subprocesses) and UTI lookups are memoized
- Warn when a change affects sibling extensions sharing the same UTI (e.g. `.env` and `.txt`)
- CI now runs the test suite

**Fixes**
- Prefer the system's UTI mapping over the hardcoded map, so `set` can no longer silently write to a UTI Finder ignores
- Validate bundle IDs during import and skip apps that aren't installed
- Restore the terminal when the TUI panics

**Install**
​```bash
brew tap ColeMei/openwith
brew install openwith
​```

Cargo source install remains available as a fallback:

​```bash
cargo install --git https://github.com/ColeMei/openwith --tag v0.4.0
​```
```

