### PR TITLE
v0.5.3 — configurable shortcut, popover pin, settings polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ crates/
     src-tauri/src/
       commands.rs       -- #[tauri::command] wrappers over openwith-core + apps cache
       tray.rs           -- tray icon lifecycle + popover positioning (plugin-positioner)
-      lib.rs            -- tauri Builder, plugins (dialog, opener, positioner, autostart, global-shortcut ⌥⌘O)
+      lib.rs            -- tauri Builder, plugins (dialog, opener, positioner, autostart, global-shortcut — default ⌥⌘O, user-configurable)
 ```
 
 ### Key patterns
@@ -93,7 +93,7 @@ crates/
 - Export/import uses serde + toml crate with `BTreeMap<String, String>` for sorted, human-readable TOML; import validates apps exist and skips associations already set correctly.
 - GUI: single `get_snapshot` command returns apps + associations (with sibling-UTI conflict data) + contested schemes in one call; the frontend is a plain render-to-innerHTML loop with `data-action` event delegation, no framework. Versions are lockstep: `tauri.conf.json` omits `version` so the app version comes from `workspace.package` in the root Cargo.toml.
 - `openwith-core::history` is the shared change log (capped at 500 events, best-effort writes that never fail the triggering change). CLI, GUI, and core import all record into it; the GUI Profiles panel shows export/import events, the menu-bar popover shows set events with per-entry Undo, and `openwith history`/`openwith undo` read the same file.
-- The GUI is two windows off one Vite bundle: `main` and a hidden transparent `menubar` popover (requires `macOSPrivateApi: true`). The popover hides on blur and is toggled by the tray icon or ⌥⌘O. A backend `AppsCache` (refreshed by `get_snapshot`) keeps popover lookups instant.
+- The GUI is two windows off one Vite bundle: `main` and a hidden transparent `menubar` popover (requires `macOSPrivateApi: true`). The popover hides on blur and is toggled by the tray icon or a configurable global shortcut (default ⌥⌘O; `set_toggle_shortcut` swaps the registration at runtime, the saved accelerator is re-applied at bootstrap). A **Pin** button suspends hide-on-blur for one showing (backend `PopoverPinned` AtomicBool, reset on every toggle) so a file can be dragged in from Finder — without it the click into Finder blurs and hides the panel. Focus events are unreliable for the transparent panel, so the backend emits `popover-shown` on every open and the popover refreshes from that, not just from focus. A backend `AppsCache` (refreshed by `get_snapshot`) keeps popover lookups instant.
 - GUI settings live in localStorage (`openwith.settings`). The Settings pane mirrors the design prototype's full layout; controls whose feature ships in a later 0.5.x phase (launch at login, menu bar) render disabled with an "arrives in v0.5.1" note rather than as silently-dead toggles.
 - GUI visual source of truth is the claude.design prototype "OpenWith GUI Explorations" (project 14225854-984c-4e5c-8d2b-8c9ce38a1624), variants 1c (light) / 2a (dark): glyph tab icons (⌸ ⊞ ⤴ ⇅ — never emoji), 2-char initial chips (20px rows / 26px app list / 52px detail), fixed mid accent oklch(0.62 0.14 45) for tab underline + toggles, inverted toast. Check UI changes against it before shipping.
 
@@ -163,7 +163,14 @@ Run against the built .app (not just `tauri dev`) before tagging any release wit
 - [ ] Appearance: flip System/Light/Dark with the popover open — both windows restyle
 - [ ] Every Settings toggle: launch at login, confirm before applying, warn on UTI conflicts, show bundle IDs, relaunch Finder, check automatically, channel, open-on-tab
 - [ ] Set a default from the Extensions sheet; verify with `openwith current <ext>`; Undo from the toast; verify again
+- [ ] Toasts dismiss themselves (~5s, ~8s with an Undo button) without being replaced
 - [ ] Popover: extension lookup, change, Recent Changes + per-entry Undo
+- [ ] Make a change in the main window, then open the popover — it appears under Recent Changes
+- [ ] Popover Pin: pin, click into Finder (panel must stay up), drag a file onto it — extension lookup runs; unpinned panel still hides on blur; Esc and tray-toggle reset the pin
+- [ ] Rebind the popover shortcut in Settings; old combo dead, new combo toggles; survives an app relaunch; ⌥⌘O labels in Settings + popover follow
+- [ ] Toggle "Warn on UTI conflicts" off — UTI ⚠ badges disappear from the Extensions table; sheet + toast warnings stay off too
+- [ ] Toggle "Show bundle IDs" off — bundle IDs vanish from Extensions table, Apps detail header, and popover rows
+- [ ] With the CLI upgraded via brew while the app runs: close and reopen Settings — the Command Line panel shows the new version without an app relaunch
 - [ ] Profiles: export; import via choose AND drag-drop; dry-run preview; apply; dismiss
 - [ ] History panel scrolls at 50 entries and updates after changes
 - [ ] Check Now (updates) reports a sensible result on both channels

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "openwith-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "openwith-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "openwith-gui"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "openwith-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/openwith-core", "crates/openwith-cli", "crates/openwith-gui/src-tauri"]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ColeMei/openwith"

--- a/crates/openwith-gui/package.json
+++ b/crates/openwith-gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openwith-gui",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/crates/openwith-gui/src-tauri/src/commands.rs
+++ b/crates/openwith-gui/src-tauri/src/commands.rs
@@ -1,7 +1,9 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
 use tauri::{AppHandle, Manager, State};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut};
 
 use openwith_core::history::{self, HistoryEvent};
 use openwith_core::types::AppInfo;
@@ -18,6 +20,28 @@ fn record_history(event: HistoryEvent) {
 /// popover lookups don't pay the multi-second scan.
 #[derive(Default)]
 pub struct AppsCache(Mutex<Option<Arc<Vec<AppInfo>>>>);
+
+/// While pinned the popover survives losing focus, so a file can be dragged
+/// in from Finder (grabbing the file blurs the popover, which normally hides
+/// it). Reset every time the popover is toggled open.
+#[derive(Default)]
+pub struct PopoverPinned(pub AtomicBool);
+
+#[tauri::command]
+pub fn set_popover_pinned(pinned: bool, state: State<'_, PopoverPinned>) {
+    state.0.store(pinned, Ordering::Relaxed);
+}
+
+/// Swap the global shortcut that toggles the popover. Only one toggle
+/// shortcut exists at a time, so replacing means unregistering everything.
+#[tauri::command]
+pub fn set_toggle_shortcut(app: AppHandle, accelerator: String) -> Result<(), String> {
+    let shortcut: Shortcut = accelerator.parse().map_err(|e| format!("{e}"))?;
+    let shortcuts = app.global_shortcut();
+    shortcuts.unregister_all().map_err(|e| e.to_string())?;
+    shortcuts.register(shortcut).map_err(|e| e.to_string())?;
+    Ok(())
+}
 
 fn cached_apps(cache: &State<'_, AppsCache>) -> Result<Arc<Vec<AppInfo>>, String> {
     let mut slot = cache.0.lock().expect("apps cache poisoned");

--- a/crates/openwith-gui/src-tauri/src/lib.rs
+++ b/crates/openwith-gui/src-tauri/src/lib.rs
@@ -1,12 +1,18 @@
 mod commands;
 mod tray;
 
+use std::sync::atomic::Ordering;
+
+use tauri::Manager;
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let toggle_shortcut = Shortcut::new(Some(Modifiers::ALT | Modifiers::SUPER), Code::KeyO);
+    // Default toggle shortcut; a saved custom one replaces it at bootstrap
+    // via the set_toggle_shortcut command. Only one shortcut is ever
+    // registered, so the handler doesn't need to know which combo it is.
+    let default_shortcut = Shortcut::new(Some(Modifiers::ALT | Modifiers::SUPER), Code::KeyO);
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -18,20 +24,28 @@ pub fn run() {
         ))
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
-                .with_shortcuts([toggle_shortcut])
+                .with_shortcuts([default_shortcut])
                 .expect("valid shortcut")
-                .with_handler(move |app, shortcut, event| {
-                    if shortcut == &toggle_shortcut && event.state == ShortcutState::Pressed {
+                .with_handler(move |app, _shortcut, event| {
+                    if event.state == ShortcutState::Pressed {
                         tray::toggle_popover(app);
                     }
                 })
                 .build(),
         )
         .manage(commands::AppsCache::default())
+        .manage(commands::PopoverPinned::default())
         .on_window_event(|window, event| match (window.label(), event) {
-            // The popover behaves like a menu: clicking anywhere else closes it.
+            // The popover behaves like a menu: clicking anywhere else closes
+            // it — unless pinned, which keeps it up for drag-and-drop.
             ("menubar", tauri::WindowEvent::Focused(false)) => {
-                let _ = window.hide();
+                let pinned = window
+                    .state::<commands::PopoverPinned>()
+                    .0
+                    .load(Ordering::Relaxed);
+                if !pinned {
+                    let _ = window.hide();
+                }
             }
             // Standard macOS behavior: the close button hides the window, the
             // app keeps running (⌘Q quits). Destroying it would make the app
@@ -59,6 +73,8 @@ pub fn run() {
             commands::quit_app,
             commands::set_tray_enabled,
             commands::set_dock_visible,
+            commands::set_popover_pinned,
+            commands::set_toggle_shortcut,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/crates/openwith-gui/src-tauri/src/tray.rs
+++ b/crates/openwith-gui/src-tauri/src/tray.rs
@@ -1,6 +1,10 @@
+use std::sync::atomic::Ordering;
+
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_positioner::{Position, WindowExt};
+
+use crate::commands::PopoverPinned;
 
 const TRAY_ID: &str = "openwith-tray";
 
@@ -45,6 +49,10 @@ pub fn toggle_popover(app: &AppHandle) {
     let Some(window) = app.get_webview_window("menubar") else {
         return;
     };
+    // Every toggle starts unpinned; pinning is a per-showing choice.
+    app.state::<PopoverPinned>()
+        .0
+        .store(false, Ordering::Relaxed);
     if window.is_visible().unwrap_or(false) {
         let _ = window.hide();
         return;
@@ -56,4 +64,7 @@ pub fn toggle_popover(app: &AppHandle) {
     }
     let _ = window.show();
     let _ = window.set_focus();
+    // Focus events are unreliable for the transparent popover panel, so tell
+    // the webview explicitly that it just opened (refresh + reset pin UI).
+    let _ = window.emit("popover-shown", ());
 }

--- a/crates/openwith-gui/src/api.ts
+++ b/crates/openwith-gui/src/api.ts
@@ -122,4 +122,8 @@ export const api = {
     invoke<void>("set_tray_enabled", { enabled }),
   setDockVisible: (visible: boolean) =>
     invoke<void>("set_dock_visible", { visible }),
+  setPopoverPinned: (pinned: boolean) =>
+    invoke<void>("set_popover_pinned", { pinned }),
+  setToggleShortcut: (accelerator: string) =>
+    invoke<void>("set_toggle_shortcut", { accelerator }),
 };

--- a/crates/openwith-gui/src/app.ts
+++ b/crates/openwith-gui/src/app.ts
@@ -22,8 +22,10 @@ import {
   saveSettings,
   schemeRole,
   sheetApps,
+  shortcutGlyphs,
   state,
   type Tab,
+  type ToastState,
 } from "./state";
 import { applyTheme, type Appearance } from "./theme";
 
@@ -71,9 +73,10 @@ function renderExtensions(): string {
     .map((r) => {
       const appName = r.app_name ?? "(none)";
       const bid = r.bundle_id ?? "";
-      const badge = r.conflict
-        ? `<span class="badge-conflict" title="Shares a UTI with sibling extensions">UTI ⚠</span>`
-        : "";
+      const badge =
+        r.conflict && state.settings.warnUtiConflicts
+          ? `<span class="badge-conflict" title="Shares a UTI with sibling extensions">UTI ⚠</span>`
+          : "";
       return `
       <div class="ext-row ${gridClass}" data-action="open-ext-sheet" data-ext="${escapeHtml(r.ext)}">
         <span class="ext-ext">.${escapeHtml(r.ext)}</span>
@@ -171,7 +174,7 @@ function renderAppDetail(app: AppDto): string {
       ${avatar(app.name, "avatar-lg")}
       <div style="min-width:0">
         <div class="app-detail-name">${escapeHtml(app.name)}</div>
-        <div class="app-detail-bid mono">${escapeHtml(app.bundle_id)}</div>
+        ${state.settings.showBundleIds ? `<div class="app-detail-bid mono">${escapeHtml(app.bundle_id)}</div>` : ""}
       </div>
       <button class="btn-claim-all" data-action="claim-all" ${stats.claimable.length === 0 ? "disabled" : ""}>Claim all supported (${stats.claimable.length})</button>
     </div>
@@ -383,8 +386,10 @@ function renderSettings(): string {
 
   const cliStatus = state.cliVersion
     ? `<span class="desc ok">✓ Installed ${escapeHtml(state.cliVersion)} — GUI and CLI share the same engine</span>`
-    : `<span class="desc">Not found — install with <span class="mono">brew install openwith</span></span>`;
-  const cliPill = state.cliVersion ? "brew upgrade openwith" : "brew install openwith";
+    : `<span class="desc">Not found — install with <span class="mono">brew install ColeMei/openwith/openwith</span></span>`;
+  const cliPill = state.cliVersion
+    ? "brew upgrade openwith"
+    : "brew install ColeMei/openwith/openwith";
 
   return `
   <div class="view settings-view">
@@ -392,7 +397,11 @@ function renderSettings(): string {
       <div class="settings-card">
         <div class="settings-card-head">GENERAL</div>
         ${toggleRow("launchAtLogin", s.launchAtLogin, "Launch at login", "Start OpenWith when you log in")}
-        ${toggleRow("showMenuBar", s.showMenuBar, "Show in menu bar", "Quick-access panel with ⌥⌘O")}
+        ${toggleRow("showMenuBar", s.showMenuBar, "Show in menu bar", `Quick-access panel with ${shortcutGlyphs(s.toggleShortcut)}`)}
+        <div class="settings-row">
+          <span><span class="label">Popover shortcut</span><span class="desc">${state.recordingShortcut ? "Press the new keys… (Esc cancels)" : "Global shortcut that toggles the quick panel"}</span></span>
+          <button class="btn-pill" data-action="record-shortcut">${state.recordingShortcut ? "…" : escapeHtml(shortcutGlyphs(s.toggleShortcut))}</button>
+        </div>
         ${toggleRow("hideDockIcon", s.hideDockIcon, "Hide Dock icon", "Menu-bar-only mode — needs the menu bar icon on", !s.showMenuBar)}
         <div class="settings-row">
           <span><span class="label">Appearance</span><span class="desc">System follows your macOS setting</span></span>
@@ -495,6 +504,22 @@ function renderSheet(): string {
       <div class="sheet-apps">${appsHtml || `<span class="italic-muted">No apps match.</span>`}</div>
     </div>
   </div>`;
+}
+
+/** Toasts dismiss themselves; ones carrying an Undo button linger longer. */
+let toastTimer: number | undefined;
+
+function showToast(toast: ToastState | null) {
+  window.clearTimeout(toastTimer);
+  state.toast = toast;
+  if (!toast) return;
+  toastTimer = window.setTimeout(
+    () => {
+      state.toast = null;
+      render();
+    },
+    toast.undo ? 8000 : 5000,
+  );
 }
 
 function renderToast(): string {
@@ -623,7 +648,7 @@ function applySetResult(result: SetResultDto, announce = true) {
     result.siblings.forEach(patchOne);
   }
   if (announce) {
-    state.toast = buildToast(result);
+    showToast(buildToast(result));
   }
 }
 
@@ -656,10 +681,10 @@ async function undoSet(setResult: SetResultDto) {
       setResult.timestamp,
     );
     applySetResult(result, false);
-    state.toast = { text: `Reverted ${result.key} → ${result.app_name}` };
+    showToast({ text: `Reverted ${result.key} → ${result.app_name}` });
     afterApply();
   } catch (e) {
-    state.toast = { text: `Undo failed: ${e}` };
+    showToast({ text: `Undo failed: ${e}` });
   }
   render();
 }
@@ -687,7 +712,7 @@ async function chooseApp(bundleId: string) {
     applySetResult(result);
     if (!result.unchanged) afterApply();
   } catch (e) {
-    state.toast = { text: `Failed: ${e}` };
+    showToast({ text: `Failed: ${e}` });
   }
   render();
 }
@@ -701,7 +726,7 @@ async function claimExt(ext: string) {
     applySetResult(result);
     if (!result.unchanged) afterApply();
   } catch (e) {
-    state.toast = { text: `Failed: ${e}` };
+    showToast({ text: `Failed: ${e}` });
   }
   render();
 }
@@ -721,7 +746,7 @@ async function claimAll() {
       // skip failures, continue claiming the rest
     }
   }
-  state.toast = { text: `Claimed ${count} extension${count === 1 ? "" : "s"} for ${app.name}` };
+  showToast({ text: `Claimed ${count} extension${count === 1 ? "" : "s"} for ${app.name}` });
   if (count > 0) afterApply();
   render();
 }
@@ -734,19 +759,19 @@ async function handleExport() {
       filters: [{ name: "TOML", extensions: ["toml"] }],
     });
   } catch (e) {
-    state.toast = { text: `Export failed: ${e}` };
+    showToast({ text: `Export failed: ${e}` });
     render();
     return;
   }
   if (!path) return;
   try {
     const result = await api.exportToml(path);
-    state.toast = {
+    showToast({
       text: `Exported ${result.association_count} associations and ${result.scheme_count} schemes`,
-    };
+    });
     refreshHistory();
   } catch (e) {
-    state.toast = { text: `Export failed: ${e}` };
+    showToast({ text: `Export failed: ${e}` });
   }
   render();
 }
@@ -760,7 +785,7 @@ async function startImportPreview(path: string) {
       preview,
     };
   } catch (e) {
-    state.toast = { text: `Import failed: ${e}` };
+    showToast({ text: `Import failed: ${e}` });
   }
   render();
 }
@@ -773,7 +798,7 @@ async function handleImportChoose() {
       filters: [{ name: "TOML", extensions: ["toml"] }],
     });
   } catch (e) {
-    state.toast = { text: `Import failed: ${e}` };
+    showToast({ text: `Import failed: ${e}` });
     render();
     return;
   }
@@ -793,13 +818,13 @@ async function applyImport() {
     const result = await api.importToml(pending.path, false);
     state.importPending = null;
     state.snapshot = await api.getSnapshot();
-    state.toast = {
+    showToast({
       text: `Applied ${result.applied.length}, unchanged ${result.unchanged}, skipped ${result.skipped.length}`,
-    };
+    });
     if (result.applied.length > 0) afterApply();
     else refreshHistory();
   } catch (e) {
-    state.toast = { text: `Import failed: ${e}` };
+    showToast({ text: `Import failed: ${e}` });
   } finally {
     state.loading = false;
     render();
@@ -838,7 +863,7 @@ function lookupDroppedFile(path: string) {
   const filename = path.split("/").pop() ?? path;
   const dot = filename.lastIndexOf(".");
   if (dot <= 0) {
-    state.toast = { text: `${filename} has no file extension` };
+    showToast({ text: `${filename} has no file extension` });
     render();
     return;
   }
@@ -875,9 +900,12 @@ async function checkForUpdates() {
     );
     if (!candidate) throw new Error("no releases found");
     state.updateStatus.latest = candidate.tag_name.replace(/^v/, "");
+    // Seconds matter: repeat "Check Now" clicks within the same minute must
+    // still visibly change something.
     state.updateStatus.checkedAt = new Date().toLocaleTimeString([], {
       hour: "2-digit",
       minute: "2-digit",
+      second: "2-digit",
     });
   } catch (e) {
     state.updateStatus.error = e instanceof Error ? e.message : String(e);
@@ -902,6 +930,20 @@ root.addEventListener("click", (e) => {
       break;
     case "settings-toggle":
       state.settingsOpen = !state.settingsOpen;
+      state.recordingShortcut = false;
+      if (state.settingsOpen) {
+        // Re-probe so a CLI installed or upgraded since launch shows up.
+        api.detectCli().then((v) => {
+          if (v !== state.cliVersion) {
+            state.cliVersion = v;
+            render();
+          }
+        });
+      }
+      render();
+      break;
+    case "record-shortcut":
+      state.recordingShortcut = !state.recordingShortcut;
       render();
       break;
     case "open-ext-sheet":
@@ -946,7 +988,7 @@ root.addEventListener("click", (e) => {
       break;
     case "undo":
       if (state.toast?.undo) state.toast.undo();
-      state.toast = null;
+      showToast(null);
       render();
       break;
     case "sheet-scope":
@@ -979,12 +1021,12 @@ root.addEventListener("click", (e) => {
         void applyLaunchAtLogin(state.settings.launchAtLogin);
       } else if (key === "showMenuBar") {
         api.setTrayEnabled(state.settings.showMenuBar).catch(() => {
-          state.toast = { text: "Couldn't update the menu bar icon" };
+          showToast({ text: "Couldn't update the menu bar icon" });
           render();
         });
       } else if (key === "hideDockIcon") {
         api.setDockVisible(!state.settings.hideDockIcon).catch(() => {
-          state.toast = { text: "Couldn't change the Dock icon" };
+          showToast({ text: "Couldn't change the Dock icon" });
           render();
         });
       }
@@ -1029,8 +1071,64 @@ root.addEventListener("input", (e) => {
   }
 });
 
+// ---------- shortcut recorder ----------
+
+/** Map a KeyboardEvent.code to a token the Rust-side accelerator parser
+ * accepts: letters, digits, and function keys. */
+function accelKeyFromCode(code: string): string | null {
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3).toLowerCase();
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5);
+  if (/^F([1-9]|1[0-2])$/.test(code)) return code.toLowerCase();
+  return null;
+}
+
+async function applyShortcut(accel: string) {
+  const previous = state.settings.toggleShortcut;
+  state.recordingShortcut = false;
+  if (accel === previous) {
+    render();
+    return;
+  }
+  try {
+    await api.setToggleShortcut(accel);
+    state.settings.toggleShortcut = accel;
+    saveSettings();
+    showToast({ text: `Popover shortcut is now ${shortcutGlyphs(accel)}` });
+  } catch (e) {
+    showToast({ text: `Couldn't set shortcut: ${e}` });
+    void api.setToggleShortcut(previous).catch(() => {});
+  }
+  render();
+}
+
+function recordShortcutKey(e: KeyboardEvent): void {
+  e.preventDefault();
+  e.stopPropagation();
+  if (e.key === "Escape") {
+    state.recordingShortcut = false;
+    render();
+    return;
+  }
+  const key = accelKeyFromCode(e.code);
+  // Keep listening through modifier-only or unsupported presses, and require
+  // a real modifier so a bare letter can't hijack global typing.
+  if (!key || (!e.metaKey && !e.ctrlKey && !e.altKey)) return;
+  const accel = [
+    e.ctrlKey ? "ctrl" : "",
+    e.altKey ? "alt" : "",
+    e.shiftKey ? "shift" : "",
+    e.metaKey ? "cmd" : "",
+    key,
+  ]
+    .filter(Boolean)
+    .join("+");
+  void applyShortcut(accel);
+}
+
 document.addEventListener("keydown", (e) => {
-  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+  if (state.recordingShortcut) {
+    recordShortcutKey(e);
+  } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
     e.preventDefault();
     let id: string;
     if (state.sheet) {
@@ -1093,6 +1191,8 @@ async function bootstrap() {
 
   // Apply persisted preferences that live outside the webview.
   api.setTrayEnabled(state.settings.showMenuBar).catch(() => {});
+  // Replace the launch-time default with the saved popover shortcut.
+  api.setToggleShortcut(state.settings.toggleShortcut).catch(() => {});
   if (state.settings.hideDockIcon && state.settings.showMenuBar) {
     api.setDockVisible(false).catch(() => {});
   }

--- a/crates/openwith-gui/src/menubar.ts
+++ b/crates/openwith-gui/src/menubar.ts
@@ -8,7 +8,12 @@ import {
   type RecentChangeDto,
 } from "./api";
 import { avatarColor, initials } from "./colors";
-import { escapeHtml } from "./state";
+import {
+  escapeHtml,
+  reloadSettings,
+  shortcutGlyphs,
+  state as shared,
+} from "./state";
 
 const root = document.getElementById("app")!;
 const popoverWindow = getCurrentWebviewWindow();
@@ -18,6 +23,8 @@ interface PopoverState {
   matches: ExtMatchDto[];
   recent: RecentChangeDto[];
   picker: { ext: string; apps: PickerAppDto[] } | null;
+  /** Pinned popovers survive losing focus, so files can be dragged in. */
+  pinned: boolean;
 }
 
 const state: PopoverState = {
@@ -25,6 +32,7 @@ const state: PopoverState = {
   matches: [],
   recent: [],
   picker: null,
+  pinned: false,
 };
 
 function chip(name: string): string {
@@ -49,12 +57,17 @@ function renderMatches(): string {
   return state.matches
     .map((m, i) => {
       const app = m.app_name ?? "(none)";
+      // "no default set" is state, not a bundle ID — show it regardless.
+      const bid =
+        shared.settings.showBundleIds || !m.bundle_id
+          ? `<span class="bid">${escapeHtml(m.bundle_id ?? "no default set")}</span>`
+          : "";
       return `
       <div class="pop-row ${i === 0 ? "first" : ""}">
         ${chip(app)}
         <span class="pop-row-text">
           <span class="line">.${escapeHtml(m.ext)} → ${escapeHtml(app)}</span>
-          <span class="bid">${escapeHtml(m.bundle_id ?? "no default set")}</span>
+          ${bid}
         </span>
         <button class="pop-link" data-action="change" data-ext="${escapeHtml(m.ext)}">Change</button>
       </div>`;
@@ -112,11 +125,12 @@ function render() {
   <div class="popover">
     <div class="pop-head">
       <span class="title">OpenWith</span>
-      <span class="hotkey">⌥⌘O</span>
+      <button class="pop-pin ${state.pinned ? "active" : ""}" data-action="pin" title="Keep the panel open while you grab a file from Finder">${state.pinned ? "Pinned ✓" : "Pin"}</button>
+      <span class="hotkey">${escapeHtml(shortcutGlyphs(shared.settings.toggleShortcut))}</span>
     </div>
     <div class="pop-dropzone">
       <div class="line1">Drop a file to look up its default</div>
-      <div class="line2">or type an extension below</div>
+      <div class="line2">${state.pinned ? "pinned — go grab a file, the panel will wait" : "type an extension below · Pin above to drag a file in"}</div>
     </div>
     <div class="pop-search">
       <span class="icon">⌕</span>
@@ -199,6 +213,11 @@ root.addEventListener("click", (e) => {
   const target = (e.target as HTMLElement).closest("[data-action]") as HTMLElement | null;
   if (!target) return;
   switch (target.dataset.action) {
+    case "pin":
+      state.pinned = !state.pinned;
+      void api.setPopoverPinned(state.pinned);
+      render();
+      break;
     case "change":
       void openPicker(target.dataset.ext!);
       break;
@@ -237,6 +256,8 @@ document.addEventListener("keydown", (e) => {
       state.picker = null;
       render();
     } else {
+      state.pinned = false;
+      void api.setPopoverPinned(false);
       void popoverWindow.hide();
     }
   }
@@ -248,6 +269,20 @@ void popoverWindow.onFocusChanged(({ payload: focused }) => {
     void refreshRecent();
     document.getElementById("pop-search")?.focus();
   }
+});
+
+// Focus events don't fire reliably for the transparent panel, so the backend
+// emits this on every open: refresh data, reset the per-showing pin state.
+void popoverWindow.listen("popover-shown", () => {
+  state.pinned = false;
+  void refreshRecent();
+  document.getElementById("pop-search")?.focus();
+});
+
+// Settings changed in the main window (shortcut, bundle IDs) reach us here.
+window.addEventListener("storage", () => {
+  reloadSettings();
+  render();
 });
 
 getCurrentWebview().onDragDropEvent((event) => {

--- a/crates/openwith-gui/src/state.ts
+++ b/crates/openwith-gui/src/state.ts
@@ -54,6 +54,8 @@ export interface SettingsState {
   autoUpdateCheck: boolean;
   updateChannel: "stable" | "beta";
   openOnTab: Tab;
+  /** Global popover toggle, in Tauri accelerator form (e.g. "alt+cmd+o"). */
+  toggleShortcut: string;
 }
 
 const SETTINGS_KEY = "openwith.settings";
@@ -70,6 +72,7 @@ const DEFAULT_SETTINGS: SettingsState = {
   autoUpdateCheck: true,
   updateChannel: "stable",
   openOnTab: "extensions",
+  toggleShortcut: "alt+cmd+o",
 };
 
 function loadSettings(): SettingsState {
@@ -90,6 +93,26 @@ export function saveSettings(): void {
   }
 }
 
+/** Re-read settings from localStorage. The popover calls this on `storage`
+ * events so main-window changes (shortcut, bundle IDs…) reach it live. */
+export function reloadSettings(): void {
+  state.settings = loadSettings();
+}
+
+/** "alt+cmd+o" → "⌥⌘O" for display, in canonical macOS modifier order. */
+export function shortcutGlyphs(accelerator: string): string {
+  const parts = accelerator.split("+").map((p) => p.trim().toLowerCase());
+  const has = (...names: string[]) => parts.some((p) => names.includes(p));
+  const key = parts[parts.length - 1] ?? "";
+  return [
+    has("ctrl", "control") ? "⌃" : "",
+    has("alt", "option") ? "⌥" : "",
+    has("shift") ? "⇧" : "",
+    has("cmd", "command", "super", "meta") ? "⌘" : "",
+    key.toUpperCase(),
+  ].join("");
+}
+
 export interface State {
   snapshot: SnapshotDto | null;
   loading: boolean;
@@ -97,6 +120,8 @@ export interface State {
 
   tab: Tab;
   settingsOpen: boolean;
+  /** Settings shortcut row is capturing the next key combo. */
+  recordingShortcut: boolean;
 
   extQuery: string;
   appsQuery: string;
@@ -125,6 +150,7 @@ export const state: State = {
 
   tab: initialSettings.openOnTab,
   settingsOpen: false,
+  recordingShortcut: false,
 
   extQuery: "",
   appsQuery: "",

--- a/crates/openwith-gui/src/styles.css
+++ b/crates/openwith-gui/src/styles.css
@@ -1215,9 +1215,31 @@ html.popover-window body {
 }
 
 .pop-head .hotkey {
-  margin-left: auto;
   font-size: 10.5px;
   color: var(--text-faintest);
+}
+
+.pop-pin {
+  margin-left: auto;
+  flex: none;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--text-faint);
+  background: var(--pill-bg);
+  border: none;
+  border-radius: 999px;
+  padding: 2px 9px;
+  cursor: default;
+  font-family: inherit;
+}
+
+.pop-pin:hover {
+  color: var(--accent);
+}
+
+.pop-pin.active {
+  color: var(--accent);
+  background: var(--pop-drop-bg);
 }
 
 .pop-dropzone {


### PR DESCRIPTION
GUI polish release fixing six issues found in real use, plus the two planned features.

## Features
- **Configurable popover shortcut** — new "Popover shortcut" recorder row in Settings (default stays ⌥⌘O). Registered at runtime, persisted, re-applied at launch; the shortcut labels in Settings and the popover header follow the binding.
- **Popover Pin** — pinning the popover suspends hide-on-blur for one showing, making drag-and-drop into the popover actually possible (clicking a file in Finder blurs the panel, which used to hide it before the drag could begin). Pin resets on every toggle and on Esc.

## Fixes
- Popover Recent Changes now updates when changes were made in the main window: the backend emits an explicit `popover-shown` event on open instead of relying on focus events, which don't fire reliably for the transparent panel.
- "Warn on UTI conflicts" off now also hides the `UTI ⚠` badges in the Extensions table (previously only gated the sheet warning and toast suffix).
- "Show bundle IDs" off now also hides bundle IDs in the Apps detail header and the popover rows (previously Extensions-table only).
- Toasts auto-dismiss after 5s (8s when they carry an Undo button) instead of staying forever.
- Settings freshness: the CLI version is re-probed every time the Settings pane opens (was launch-only, so a `brew upgrade` never showed without relaunching); "last checked" includes seconds so repeated Check Now clicks visibly do something.
- The Command Line install hint is tap-qualified: `brew install ColeMei/openwith/openwith` (the bare form fails without the tap).

## Notes
- Beta channel remains a placeholder in practice until a prerelease exists on GitHub — the code path is real (includes prereleases), there's just nothing on that channel yet.
- Version bumped to 0.5.3 (lockstep). 