### PR TITLE
ci: typecheck and build the GUI frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,25 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test
         run: cargo test
+
+  gui:
+    # Pure node — no macOS-only APIs in the frontend build, and Linux runners
+    # start faster.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: crates/openwith-gui/package-lock.json
+      # Typechecks the frontend (tsc) and builds the Vite bundle. The Rust side
+      # of the Tauri app is already covered by the `rust` job's workspace-wide
+      # check/clippy, so this deliberately stops short of a full `tauri build`
+      # — that needs a bundle step measured in minutes, not seconds.
+      - name: Install frontend deps
+        working-directory: crates/openwith-gui
+        run: npm ci
+      - name: Typecheck + build frontend
+        working-directory: crates/openwith-gui
+        run: npm run build


### PR DESCRIPTION
CI ran `fmt`/`check`/`clippy`/`test` but never touched the frontend — no `npm ci`, no `npm run build`. TypeScript errors and Vite/`tauri.conf.json` breakage were caught only by hand, which is a gap the manual GUI smoke-test checklist was quietly absorbing.

Adds a `gui` job running `npm ci` + `npm run build` (which is `tsc && vite build`, so it typechecks as well as bundles).

- Runs on `ubuntu-latest`: nothing in the frontend build is macOS-specific, and Linux runners start faster.
- Stops short of a full `tauri build` on purpose — the Rust side of the app is already covered by the `rust` job's workspace-wide `check`/`clippy`, and bundling costs minutes rather than seconds.
- npm cache keyed on `crates/openwith-gui/package-lock.json`.

Verified `npm ci` succeeds against the committed lockfile.