### PR TITLE
fix: restore --help on every subcommand

### DIFF
--- a/crates/openwith-cli/src/cli.rs
+++ b/crates/openwith-cli/src/cli.rs
@@ -41,17 +41,12 @@ FLAGS
     name = "openwith",
     about = "Manage macOS file extension associations",
     version,
-    disable_version_flag = true,
-    disable_help_flag = true
+    disable_version_flag = true
 )]
 pub struct Cli {
     /// Print version
     #[arg(short = 'v', long = "version", action = clap::ArgAction::Version)]
     pub version: (),
-
-    /// Print help
-    #[arg(short = 'h', long = "help", action = clap::ArgAction::HelpLong)]
-    pub help: (),
 
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -61,6 +56,11 @@ impl Cli {
     pub fn parse_with_help() -> Self {
         use clap::CommandFactory;
         let mut cmd = Self::command();
+        // Only the root gets the hand-written logo template; subcommands keep
+        // clap's generated help, which lists their actual flags. `-h`/`--help`
+        // stay enabled everywhere — disabling them at the root propagated to
+        // every subcommand, leaving `openwith set --help` an "unexpected
+        // argument" error.
         cmd = cmd.help_template(help_template());
         let matches = cmd.get_matches();
         Self::from_arg_matches(&matches).expect("failed to parse CLI arguments")
@@ -145,4 +145,36 @@ pub enum Commands {
     /// Generate a man page (roff) on stdout
     #[command(hide = true)]
     Mangen,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn cli_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    /// `disable_help_flag` on the root propagates to subcommands, which once
+    /// left every `openwith <sub> --help` failing as an unexpected argument
+    /// while the root's own help still worked — so the breakage was invisible
+    /// unless a subcommand was tried directly.
+    #[test]
+    fn every_subcommand_accepts_help() {
+        let mut cmd = Cli::command();
+        cmd.build();
+        for sub in cmd.get_subcommands() {
+            // clap's own `openwith help <sub>` command takes no flags itself.
+            if sub.get_name() == "help" {
+                continue;
+            }
+            assert!(
+                sub.get_arguments().any(|a| a.get_id() == "help"),
+                "`openwith {}` has no --help flag",
+                sub.get_name()
+            );
+        }
+    }
 }


### PR DESCRIPTION
`openwith set --help`, `openwith history --help` — and the same for every other subcommand, with `-h` too — failed with `error: unexpected argument '--help' found` (exit 2).

## Cause

`disable_help_flag = true` on the root `Cli` **propagates to every subcommand** in clap v4. The manual field beneath it put `-h`/`--help` back only at the root:

```rust
#[arg(short = 'h', long = "help", action = clap::ArgAction::HelpLong)]
pub help: (),
```

So subcommands had the flag disabled with nothing restoring it. `openwith --help` kept rendering the logo screen the whole time, which is why this survived since the custom help template was introduced.

## Fix

Drop `disable_help_flag` and the manual field, and set the logo `help_template` on the root command only. Subcommands fall back to clap's generated help, which lists their real flags:

```
Usage: openwith history [OPTIONS]

Options:
  -n, --limit <LIMIT>  Maximum number of events to show [default: 20]
  -d, --days <DAYS>    Only show events from the last N days [default: 7]
      --all            Show every retained event, ignoring --days
      --json           Print JSON
```

`disable_version_flag` and its manual field stay — `--version` belongs to the root alone and was never affected.

## Verified

- Root `--help` **and** `-h` still render the ASCII-logo template
- `--version` / `-v` unchanged
- All 9 subcommands accept both `--help` and `-h`
- `openwith help <sub>` works as well
- `completions` (zsh/bash/fish) and `mangen` still produce output — the Homebrew formula calls both during install
- Normal operation (`current`, `history`) unaffected

Two tests added. `every_subcommand_accepts_help` is a genuine guard: it was confirmed to **fail** against the old definition (`` `openwith list` has no --help flag ``) and pass against the fix.

Not tagging a release for this — it'll ride along with the next batch of changes.